### PR TITLE
#72 デプロイができるように設定

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -1,6 +1,6 @@
 name: Fly Deploy
 on:
-  push:
+  pull_request:
     branches:
       - main
     paths:

--- a/back/config/database.yml
+++ b/back/config/database.yml
@@ -10,3 +10,7 @@ development:
   password: password
   database: app_development
   host: db
+
+test:
+  <<: *default
+  database: app_test

--- a/back/config/initializers/devise.rb
+++ b/back/config/initializers/devise.rb
@@ -19,9 +19,7 @@ Devise.setup do |config|
 
   # JWTの設定
   config.jwt do |jwt|
-    jwt.secret = Rails.application.credentials.dig(:jwt, :secret)
-    raise "JWT Secret Keyが設定されていません。" unless jwt.secret.present?
-
+    jwt.secret = ENV['JWT_SECRET_KEY'] || Rails.application.credentials.dig(:jwt, :secret)
     jwt.dispatch_requests = [
       ['POST', %r{^/login$}]
     ]


### PR DESCRIPTION
Closes #

## 概要
[![Image from Gyazo](https://i.gyazo.com/44bd0af2ce76833c70914ba3c19890ab.png)](https://gyazo.com/44bd0af2ce76833c70914ba3c19890ab)

Github  Actionsで上記のエラー。
- Fly.ioのデプロイ時にJWT Secret Keyが設定されていませんというエラーが発生しているため、config/initializers/devise.rb内でJWTシークレットキーの設定を行う
- アプリ名を明示的に指定するため、-a <app_name>フラグを追加して実行
- Fly.ioのデプロイ環境において、JWTシークレットキーを環境変数として設定する

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。以下のように記述。 -->
- 関連Issue: #72
