### PR TITLE
【フロント・バック】一覧を取得して表示（未検索時

### DIFF
--- a/back/app/controllers/api/v1/books_controller.rb
+++ b/back/app/controllers/api/v1/books_controller.rb
@@ -1,6 +1,17 @@
 class Api::V1::BooksController < ApplicationController
   before_action :authenticate_user!, only: [:create]
 
+  def index
+    books = Book.all
+    render json: books.as_json(
+      only: [:id, :title, :author_name, :created_at],
+      include: {
+        pages: { only: [:page_number] },
+        tags: { only: [:name] }
+      }
+    ), status: :ok
+  end
+
   def create
     book = current_user.books.build(book_params)
     if book.save

--- a/front/src/app/index-books/page.jsx
+++ b/front/src/app/index-books/page.jsx
@@ -1,7 +1,57 @@
-export default function LoginPage() {
+"use client";
+
+import React, { useEffect, useState } from "react";
+import axios from "../../api/axios";
+
+function BookListPage() {
+  const [books, setBooks] = useState([]); // 絵本データを格納
+  const [loading, setLoading] = useState(true); // ローディング状態
+
+  useEffect(() => {
+    // APIからデータを取得
+    const fetchBooks = async () => {
+      try {
+        const response = await axios.get("/api/v1/books");
+        const sortedBooks = response.data.sort(
+          (a, b) => new Date(b.created_at) - new Date(a.created_at) // 新しい順にソート
+        );
+        setBooks(sortedBooks);
+        setLoading(false);
+      } catch (error) {
+        console.error("Error fetching books:", error);
+        setLoading(false);
+      }
+    };
+
+    fetchBooks();
+  }, []);
+
+  if (loading) return <p>Loading...</p>;
+
   return (
-    <div className="flex items-center justify-center min-h-screen">
-      <h1 className="text-2xl font-bold text-gray-700">絵本一覧ページ。これから</h1>
+    <div className="flex flex-col items-center justify-center p-8 space-y-8">
+      <h1 className="text-3xl font-bold mb-6">みんなの絵本</h1>
+      <div className="space-y-4">
+        {books.map((book) => (
+          <div
+            key={book.id}
+            className="flex items-center justify-between p-4 bg-white bg-opacity-50 rounded-lg shadow-md"
+          >
+            <div>
+              <h2 className="text-xl font-semibold">{book.title}</h2>
+              <p className="text-bodyText text-sm">作者: {book.author_name}</p>
+            </div>
+            <button
+              onClick={() => window.location.href = `/books/${book.id}`}
+              className="px-4 py-2 ml-4 bg-customButton text-white rounded-md hover:brightness-90"
+            >
+              読む
+            </button>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }
+
+export default BookListPage;


### PR DESCRIPTION
Closes #44

## 概要（Summary）
バックエンドから未検索状態で新着順の絵本一覧データを取得し、フロントエンドで表示する機能を実装します。絵本一覧は1ページあたり20件を取得し、新着順で全体公開のデータのみ表示されます。

## ゴール（Goals）
- [x] 未検索時の一覧表示
- [x] ナビゲーションボタンが表示されること（右）
- [x] 各絵本の詳細ページへ遷移すること
- [x] 操作感やUXが悪くないか確認すること
- [x] フロントエンドがバックエンドのAPIを呼び出し、絵本一覧データを取得すること
- [x] 各絵本のID（リンク用スラッグ）、作者、タイトル、詳細が表示されること
- [x] エラーが発生した場合、エラーメッセージをユーザーに表示すること

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- 

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- 

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- 

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- 

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- 

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。以下のように記述。 -->
- 関連Issue: #44
