### PR TITLE
【フロント】ヘッダーのtokenをfront/src/api/axios.jsでまとめて行う

### DIFF
--- a/front/src/api/axios.js
+++ b/front/src/api/axios.js
@@ -9,4 +9,50 @@ const axiosInstance = axios.create({
   },
 });
 
+// リクエストインターセプターを追加して、Authorization ヘッダーを自動設定
+axiosInstance.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem('access_token');
+    if (token) {
+      config.headers['Authorization'] = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+// レスポンスインターセプターを追加して、401 エラーをグローバルに処理
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+    if (error.response && error.response.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      try {
+        const refreshToken = localStorage.getItem('refresh_token');
+        if (refreshToken) {
+          const response = await axios.post(`${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/refresh`, {
+            refresh_token: refreshToken,
+          });
+          const newAccessToken = response.data.access_token;
+          localStorage.setItem('access_token', newAccessToken);
+          axiosInstance.defaults.headers['Authorization'] = `Bearer ${newAccessToken}`;
+          originalRequest.headers['Authorization'] = `Bearer ${newAccessToken}`;
+          return axiosInstance(originalRequest);
+        }
+      } catch (refreshError) {
+        console.error('リフレッシュトークンの更新に失敗しました:', refreshError);
+        // リフレッシュトークンの更新に失敗した場合、ユーザーをログアウトさせる処理
+        localStorage.removeItem('access_token');
+        localStorage.removeItem('refresh_token');
+        window.location.href = '/login';
+        return Promise.reject(refreshError);
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
 export default axiosInstance;

--- a/front/src/app/components/BookDetailPage.jsx
+++ b/front/src/app/components/BookDetailPage.jsx
@@ -86,9 +86,6 @@ function BookDetailPage() {
     const checkAuthorStatus = async () => {
       try {
         const response = await axios.get(`/api/v1/books/${bookId}/author_status`, {
-          headers: {
-            Authorization: `Bearer ${localStorage.getItem('access_token')}`, // ローカルストレージからトークンを取得
-          },
         });
         setIsAuthor(response.data.is_author); // 作者かどうかを状態に設定
       } catch (error) {
@@ -126,17 +123,7 @@ function BookDetailPage() {
     const confirmDelete = window.confirm("この絵本を削除しますか？");
     if (!confirmDelete) return;
     try {
-      const token = localStorage.getItem("access_token");
-      if (!token) {
-        alert("ログイン状態が無効です。再度ログインしてください。");
-        return;
-      }
-      // APIリクエストの送信
-      await axios.delete(`/api/v1/books/${bookId}`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
+      await axios.delete(`/api/v1/books/${bookId}`);
       alert("絵本を削除しました。");
       router.push("/index-books"); // 削除後にリスト画面にリダイレクト
     } catch (error) {

--- a/front/src/app/components/ModalManager.jsx
+++ b/front/src/app/components/ModalManager.jsx
@@ -84,18 +84,6 @@ export default function ModalManager() {
   // モーダル保存処理
   const handleModalSave = async () => {
     try {
-      let token = localStorage.getItem('access_token');
-      if (!token) {
-        alert("ログイン状態が無効です。再度ログインしてください。");
-        return;
-      }
-
-      if (checkTokenExpiration(token)) {
-        token = await refreshAccessToken();
-      }
-
-      const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
-
       // 書籍データのペイロード
       const bookDataPayload = {
         title: modalData.title,
@@ -111,12 +99,12 @@ export default function ModalManager() {
       // 書籍の更新または新規作成
       if (newBookId) {
         // 更新
-        const updateBookResponse = await axios.put(`/api/v1/books/${newBookId}`, bookDataPayload, { headers });
+        const updateBookResponse = await axios.put(`/api/v1/books/${newBookId}`, bookDataPayload);
         console.log(`Book updated with id: ${updateBookResponse.data.book.id}`);
         isUpdate = true;
       } else {
         // 新規作成
-        const createBookResponse = await axios.post('/api/v1/books', bookDataPayload, { headers });
+        const createBookResponse = await axios.post('/api/v1/books', bookDataPayload);
         newBookId = createBookResponse.data.book.id;
         console.log(`New book created with id: ${newBookId}`);
       }
@@ -166,10 +154,10 @@ export default function ModalManager() {
 
         if (page.id) {
           // ページ更新
-          await axios.put(`/api/v1/books/${newBookId}/pages/${page.id}`, payload, { headers });
+          await axios.put(`/api/v1/books/${newBookId}/pages/${page.id}`, payload);
         } else {
           // 新規作成
-          await axios.post(`/api/v1/books/${newBookId}/pages`, payload, { headers });
+          await axios.post(`/api/v1/books/${newBookId}/pages`, payload);
         }
       }
 


### PR DESCRIPTION
Closes #110

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
リクエストの際に毎回ヘッダーにトークンを入れるのをなくすためにリクエストインターセプターを使用します。

## やったこと
<!-- このプルリクで何をしたのか？ -->
- axiousのリクエストインターセプターを追加して、Authorization ヘッダーを自動設定

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- なし

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ローカル環境で確認

## 参考
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- [Axious公式](https://axios-http.com/ja/docs/interceptors)
- [Axiosしているならエラーハンドリングはinterceptors一択](https://zenn.dev/nbr41to/articles/c7fc2ff1f9946e)

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。以下のように記述。 -->
- 関連Issue: #110
