### PR TITLE
CanvasコンポーネントにisReadOnlyというプロパティを追加

### DIFF
--- a/front/src/app/components/BookDetailPage.jsx
+++ b/front/src/app/components/BookDetailPage.jsx
@@ -17,8 +17,6 @@ function BookDetailPage() {
   const {
     bookData,
     currentPageIndex,
-    updateImage,
-    deleteImage,
     pages,
     fetchBookData,
   } = useCanvasStore();
@@ -84,15 +82,8 @@ function BookDetailPage() {
       {/* キャンバス */}
       {pages.length > 0 && pages[currentPageIndex] && (
         <Canvas
-          pageElements={pages[currentPageIndex].pageElements}
-          pageData={pages[currentPageIndex]}
-          backgroundColor={pages[currentPageIndex]?.backgroundColor || "#ffffff"}
-          onUpdateImage={updateImage}
-          onDeleteImage={deleteImage}
-          onSelectText={(index) => {
-            useCanvasStore.getState().setSelectedTextIndex(index);
-          }}
           showActionButtons={false}
+          isReadOnly={true}
         />
       )}
 

--- a/front/src/app/components/Canvas.jsx
+++ b/front/src/app/components/Canvas.jsx
@@ -7,7 +7,7 @@ import { FaChevronCircleLeft, FaChevronCircleRight } from "react-icons/fa";
 import { useRouter } from 'next/navigation';
 import ModalManager from './ModalManager';
 
-function Canvas({ showActionButtons }) {
+function Canvas({ showActionButtons, isReadOnly }) {
   const {
     selectedTextIndex,
     selectedImageIndex,
@@ -116,6 +116,7 @@ function Canvas({ showActionButtons }) {
 
   // ドラッグ終了時の処理
   const handleDragEnd = (index, e, type) => {
+    if (isReadOnly) return;
     const update = {
       positionX: e.target.x(),
       positionY: e.target.y()
@@ -129,6 +130,7 @@ function Canvas({ showActionButtons }) {
 
   // 変形終了時の処理
   const handleTransformEnd = (index, e, type) => {
+    if (isReadOnly) return;
     const node = type === 'text' ? textRefs.current[index] : imageRefs.current[index];
     const newProperties = {
       positionX: node.x(),
@@ -163,6 +165,7 @@ function Canvas({ showActionButtons }) {
 
   // テキストクリック時の処理
   const handleTextClick = (index) => {
+    if (isReadOnly) return;
     console.log("Text clicked at index:", index);
     setSelectedTextIndex(index);
     setSelectedImageIndex(null);
@@ -170,6 +173,7 @@ function Canvas({ showActionButtons }) {
 
   // 画像クリック時の処理
 const handleImageClick = (index) => {
+  if (isReadOnly) return;
   console.log("Image clicked at index:", index);
   setSelectedImageIndex(index);
   setSelectedTextIndex(null);
@@ -217,7 +221,7 @@ const handleImageClick = (index) => {
                 text={element.text}
                 x={element.positionX}
                 y={element.positionY}
-                draggable
+                draggable={!isReadOnly}
                 onDragEnd={(e) => handleDragEnd(index, e, 'text')}
                 onTransformEnd={(e) => handleTransformEnd(index, e, 'text')}
                 fontSize={element.fontSize}
@@ -238,7 +242,7 @@ const handleImageClick = (index) => {
                   image={loadedImage.image}
                   x={element.positionX}
                   y={element.positionY}
-                  draggable
+                  draggable={!isReadOnly}
                   onDragEnd={(e) => handleDragEnd(index, e, 'image')}
                   onTransformEnd={(e) => handleTransformEnd(index, e, 'image')}
                   onClick={() => { handleImageClick(index); }}
@@ -250,7 +254,7 @@ const handleImageClick = (index) => {
             }
             return null;
           })}
-          {(selectedTextIndex !== null || selectedImageIndex !== null) && (
+          {(!isReadOnly && (selectedTextIndex !== null || selectedImageIndex !== null)) && (
             <Transformer ref={transformerRef} anchorSize={8} borderDash={[6, 2]} keepRatio={true} />
           )}
         </Layer>


### PR DESCRIPTION
Closes #118

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
現在、絵本の詳細ページにおいてユーザーが内容を編集できる状態になっています。しかし、実際には編集内容を保存する機能が実装されておらず、ユーザーが誤って変更を加えた際に混乱を招く可能性があります。詳細ページでは表示のみとし、編集機能を無効化する必要があります。

## やったこと
<!-- このプルリクで何をしたのか？ -->
- [x] CanvasコンポーネントにisReadOnlyというプロパティを追加し、読み取り専用モードの導入
- [x] このプロパティに基づいて、インタラクションを制御
- [x] Canvasコンポーネント内でisReadOnlyを参照し、ドラッグや拡大縮小、削除などの機能を無効化
- [x] 詳細ページからCanvasコンポーネントにisReadOnly={true}を渡す

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- 詳細ページでテキストやイメージが触れなくした

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ローカルでのみ動作確認

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- なし
