### PR TITLE
 【フロント】詳細ページから新規作成ページに行くと、詳細ページの内容が反映されている

### DIFF
--- a/front/src/app/create-book/page.jsx
+++ b/front/src/app/create-book/page.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import CreateBookFooter from '../components/CreateBookFooter';
 import useCanvasStore from '../../stores/canvasStore';
 
@@ -17,6 +17,7 @@ export default function CreateBookPage() {
     currentPageIndex,
     handleAddText,
     setBackgroundColor,
+    resetCanvas,
   } = useCanvasStore();
 
   const currentPage = pages[currentPageIndex] || {
@@ -24,6 +25,11 @@ export default function CreateBookPage() {
     pageCharacters: [],
     backgroundColor: '#ffffff',
   };
+
+  useEffect(() => {
+    // 作成ページに遷移したらストアをリセット
+    resetCanvas();
+  }, [resetCanvas]);
 
   const togglePanel = (panelName) => {
     setActivePanel(activePanel === panelName ? null : panelName);


### PR DESCRIPTION
Closes #120

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
現在、詳細ページ（例：/books/67）を閲覧した後に新規作成ページ（/create-book）へ遷移すると、詳細ページで取得した内容が新規作成ページにも引き継がれてしまう問題が発生しています。このため、新規作成ページで意図しない内容が表示され、ユーザーに混乱を招いています。

## やったこと
<!-- このプルリクで何をしたのか？ -->
- [x] useCanvasStore に既に実装されている resetCanvas を使って新規作成ページでのストアリセットの実装
- [x] 新規作成ページ（/create-book）がマウントされた際に、resetCanvas を呼び出してストアの状態をリセットするように実装


## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- 詳細ページから作成ページへ遷移してもデータが引き継がれなくなった

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ローカルでのみ動作確認

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- なし

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。以下のように記述。 -->
- 関連Issue: #120
