### PR TITLE
【バック・フロント】背景色の記憶と反映

### DIFF
--- a/front/src/app/components/LoginForm.jsx
+++ b/front/src/app/components/LoginForm.jsx
@@ -90,15 +90,6 @@ export default function LoginForm() {
           </button>
         </div>
       </form>
-
-      {/* デバッグ情報を表示 */}
-      {debugInfo && (
-        <div className="mt-4 p-4 border rounded bg-gray-100">
-          <h3 className="text-lg font-semibold">デバッグ情報</h3>
-          <p>Access Token: {debugInfo.access_token}</p>
-          <p>Refresh Token: {debugInfo.refresh_token}</p>
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #142

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
そのBooksで使用した背景色を、背景色タブ内に表示し、ユーザーがクリックしてページに即反映できるようにする。ユーザーが以前使用した背景色を再利用できるようにすることで、一貫性のあるデザインを容易にし、操作性と効率を向上させる。

## やったこと
<!-- このプルリクで何をしたのか？ -->
- [x]  バックエンドから背景色データを取得
- [x] フロントエンドで背景色を表示
- [x] 背景色をクリックでページに反映
- [x] 現在の背景色をハイライト

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- 使った背景色を再度使いやすくする

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- なそ

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ローカルと本番環境で動作確認

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- なし