### PR TITLE
 【フロント・バック】画面のサイズに応じてスタンプのサイズを動的にする

### DIFF
--- a/front/src/app/components/BookDetailPage.jsx
+++ b/front/src/app/components/BookDetailPage.jsx
@@ -73,13 +73,13 @@ function BookDetailPage() {
   if (!bookData) return <p>Loading...</p>;
 
   return (
-    <div className="flex flex-col items-center justify-center p-8 space-y-8">
-      {/* タイトルと著者 */}
-      <div className="text-center">
-        <h1 className="text-3xl font-bold mb-2">{bookData.title}</h1>
-        <p className="text-lg text-bodyText">作者: {bookData.author_name}</p>
-      </div>
-
+    <>
+    {/* タイトルと著者を外側に移動 */}
+    <div className="text-center mt-4">
+      <h1 className="text-3xl font-bold mb-2">{bookData.title}</h1>
+      <p className="text-lg text-bodyText">作者: {bookData.author_name}</p>
+    </div>
+    <div className="flex flex-col items-center justify-center space-y-4 overflow-y-auto w-full min-h-0 mb-40">
       {/* キャンバス */}
       {pages.length > 0 && pages[currentPageIndex] && (
         <Canvas
@@ -88,7 +88,6 @@ function BookDetailPage() {
           allowAddPage={false}
         />
       )}
-
       {/* アイコンボタン */}
       <div className="flex space-x-6">
         <button
@@ -125,6 +124,7 @@ function BookDetailPage() {
         )}
       </div>
     </div>
+    </>
   );
 }
 

--- a/front/src/stores/canvasStore.jsx
+++ b/front/src/stores/canvasStore.jsx
@@ -219,7 +219,6 @@ const useCanvasStore = create((set, get) => ({
       return {
         pages: updatedPages,
         currentPageIndex: updatedPages.length - 1,
-        history: [...history, pages],
       };
     });
   },


### PR DESCRIPTION
Closes #146

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
キャンバスサイズの変更に伴い、スタンプやテキストのサイズと位置が相対的に変化し、構図が維持されるようにする機能を実装する。

## やったこと
<!-- このプルリクで何をしたのか？ -->
- [x]  仮想キャンバスサイズ (VIRTUAL_CANVAS_WIDTH, VIRTUAL_CANVAS_HEIGHT) を定義する
- [x] ウィンドウリサイズ時に実際のキャンバスサイズを計算し、スケールファクター (scaleX, scaleY) を適用
- [x] 要素（テキスト、画像）の位置・サイズを仮想座標系で管理
- [x] ドラッグ・変形イベントの処理で仮想座標系を考慮
- [x] スケーリング適用後にステージと要素のレンダリングを確認
- [x] コードのリファクタリングと必要なコメント追加
- [x] ユーザーテストを実施し、意図した動作を確認

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- 画面の大きさが変わってもレイアウトが崩れないようになった

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ローカルと本番環境で動作確認