### PR TITLE
画面サイズが大きいとサイドバーを左に固定

### DIFF
--- a/front/src/app/books/[bookId]/edit/page.jsx
+++ b/front/src/app/books/[bookId]/edit/page.jsx
@@ -5,11 +5,13 @@ import { useParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import useCanvasStore from "../../../../stores/canvasStore";
 import CreateBookFooter from "@/app/components/CreateBookFooter";
+import useIsMobile from "@/hooks/useIsMobile";
 
 const Canvas = dynamic(() => import("../../../components/Canvas"), { ssr: false });
 
 function EditBookPage() {
   const { bookId } = useParams();
+  const isMobile = useIsMobile();
 
   const {
     setBackgroundColor,
@@ -39,29 +41,25 @@ function EditBookPage() {
   if (!bookData) return <p>Loading...</p>;
 
   return (
-    <div className="flex flex-col items-center justify-center p-8">
-      {/* タイトルと著者 */}
-      <div className="text-center">
-        <h1 className="text-3xl font-bold mb-2">{bookData.title}</h1>
-        <p className="text-lg text-bodyText">作者: {bookData.author_name}</p>
-      </div>
-
+    <div className={`flex flex-col overflow-y-auto ${isMobile ? 'items-center' : 'items-end'}`}>
       {/* キャンバス */}
-      {pages.length > 0 && pages[currentPageIndex] && (
-        <Canvas
-          pageElements={pages[currentPageIndex].pageElements}
-          pageData={pages[currentPageIndex]}
-          backgroundColor={pages[currentPageIndex]?.backgroundColor || "#ffffff"}
-          onUpdateImage={updateImage}
-          onDeleteImage={deleteImage}
-          onSelectText={(index) => {
-            useCanvasStore.getState().setSelectedTextIndex(index);
-          }}
-          showActionButtons={true}
-          allowAddPage={true}
-          showUndoButton={true}
-        />
-      )}
+      <div className={`max-w-none ${isMobile ? 'mx-auto' : 'mr-10'}`}>
+        {pages.length > 0 && pages[currentPageIndex] && (
+          <Canvas
+            pageElements={pages[currentPageIndex].pageElements}
+            pageData={pages[currentPageIndex]}
+            backgroundColor={pages[currentPageIndex]?.backgroundColor || "#ffffff"}
+            onUpdateImage={updateImage}
+            onDeleteImage={deleteImage}
+            onSelectText={(index) => {
+              useCanvasStore.getState().setSelectedTextIndex(index);
+            }}
+            showActionButtons={true}
+            allowAddPage={true}
+            showUndoButton={true}
+          />
+        )}
+      </div>
 
       {/* フッター */}
       <CreateBookFooter

--- a/front/src/app/components/BookCard.jsx
+++ b/front/src/app/components/BookCard.jsx
@@ -1,10 +1,22 @@
-import React from 'react';
+'use client';
 
-function BookCard({ title, description, imageSrc, altText, additionalInfo }) {
+import React from 'react';
+import { useRouter } from 'next/navigation';
+
+function BookCard({ title, description, imageSrc, altText, additionalInfo, path }) {
+  const router = useRouter();
+
+  const handleClick = () => {
+    if (path) {
+      router.push(path);
+    }
+  };
+
   return (
     <div
-      className="card w-80 shadow-xl mx-auto p-4 mb-4"
+      className="card w-80 shadow-xl mx-auto p-4 mb-4 cursor-pointer"
       style={{ backgroundColor: "rgba(255, 255, 255, 0.5)" }}
+      onClick={handleClick}
     >
       <div className="card-body">
         <h2 className="card-title text-lg font-semibold mb-2 text-heading">{title}</h2>

--- a/front/src/app/components/BookDetailPage.jsx
+++ b/front/src/app/components/BookDetailPage.jsx
@@ -6,12 +6,14 @@ import dynamic from "next/dynamic";
 import axiosInstance from '../../api/axios';
 import { FaRegCommentDots, FaPrint, FaEdit, FaTrash } from 'react-icons/fa';
 import useCanvasStore from '../../stores/canvasStore';
+import useIsMobile from "@/hooks/useIsMobile";
 
 const Canvas = dynamic(() => import("./Canvas"), { ssr: false });
 
 function BookDetailPage() {
   const { bookId } = useParams();
   const router = useRouter();
+  const isMobile = useIsMobile();
 
   // Zustandストアから状態とアクションを取得
   const {
@@ -27,10 +29,9 @@ function BookDetailPage() {
   // 書籍データの取得
   useEffect(() => {
     if (bookId) {
-      fetchBookData(bookId).then(() => {
-      });
+      fetchBookData(bookId).then(() => {});
     }
-  }, [bookId, fetchBookData]); // pagesを依存配列から除外
+  }, [bookId, fetchBookData]);
 
   // 作者判定APIを呼び出し
   useEffect(() => {
@@ -73,59 +74,58 @@ function BookDetailPage() {
   if (!bookData) return <p>Loading...</p>;
 
   return (
-    <>
-    {/* タイトルと著者を外側に移動 */}
-    <div className="text-center mt-4">
-      <h1 className="text-3xl font-bold mb-2">{bookData.title}</h1>
-      <p className="text-lg text-bodyText">作者: {bookData.author_name}</p>
-    </div>
-    <div className="flex flex-col items-center justify-center space-y-4 overflow-y-auto w-full min-h-0 mb-40">
-      {/* キャンバス */}
-      {pages.length > 0 && pages[currentPageIndex] && (
-        <Canvas
-          showActionButtons={false}
-          isReadOnly={true}
-          allowAddPage={false}
-          showUndoButton={false}
-        />
-      )}
-      {/* アイコンボタン */}
-      <div className="flex space-x-6">
-        <button
-          onClick={handleComment}
-          className="flex flex-col items-center justify-center p-4 border border-bodyText rounded-md text-bodyText hover:bg-gray-100 transition"
-        >
-          <FaRegCommentDots className="text-bodyText" size={32} />
-          <span className="text-sm mt-2">コメント</span>
-        </button>
-        <button
-          onClick={handlePrint}
-          className="flex flex-col items-center justify-center p-4 border border-bodyText rounded-md text-bodyText hover:bg-gray-100 transition"
-        >
-          <FaPrint className="text-bodyText" size={32} />
-          <span className="text-sm mt-2">印刷する</span>
-        </button>
-        {isAuthor && (
-          <>
-            <button
-              onClick={handleEdit}
-              className="flex flex-col items-center justify-center p-4 border border-bodyText rounded-md text-bodyText hover:bg-gray-100 transition"
-            >
-              <FaEdit className="text-bodyText" size={32} />
-              <span className="text-sm mt-2">編集する</span>
-            </button>
-            <button
-              onClick={handleDelete}
-              className="flex flex-col items-center justify-center p-4 border border-bodyText rounded-md text-bodyText hover:bg-gray-100 transition"
-            >
-              <FaTrash className="text-bodyText" size={32} />
-              <span className="text-sm mt-2">削除する</span>
-            </button>
-          </>
+    <div className="flex flex-col items-center justify-center">
+      {/* メインコンテナ: モバイルはflex-col, デスクトップはflex-row */}
+      <div className={`flex ${isMobile ? 'flex-col' : 'flex-row'} items-center justify-center space-y-4 ${!isMobile ? 'space-y-0 space-x-6' : ''} w-full max-w-5xl`}>
+        {/* キャンバスコンテナ */}
+        {pages.length > 0 && pages[currentPageIndex] && (
+          <div className="flex-shrink-0">
+            <Canvas
+              showActionButtons={false}
+              isReadOnly={true}
+              allowAddPage={false}
+              showUndoButton={false}
+            />
+          </div>
         )}
+
+        {/* アイコンボタンコンテナ: モバイルはflex-row, デスクトップはflex-col */}
+        <div className={`flex ${isMobile ? 'flex-row' : 'flex-col'} ${isMobile ? 'space-x-6' : 'space-y-4'}`}>
+          <button
+            onClick={handleComment}
+            className="flex flex-col items-center justify-center p-2 border border-gray-400 rounded-md text-gray-700 hover:bg-gray-100 transition w-16 h-16"
+          >
+            <FaRegCommentDots className="text-gray-700" size={24} />
+            <span style={{ fontSize: '0.6rem' }} className="mt-1">コメント</span>
+          </button>
+          <button
+            onClick={handlePrint}
+            className="flex flex-col items-center justify-center p-2 border border-gray-400 rounded-md text-gray-700 hover:bg-gray-100 transition w-16 h-16"
+          >
+            <FaPrint className="text-gray-700" size={24} />
+            <span style={{ fontSize: '0.6rem' }} className="mt-1">印刷する</span>
+          </button>
+          {isAuthor && (
+            <>
+              <button
+                onClick={handleEdit}
+                className="flex flex-col items-center justify-center p-2 border border-gray-400 rounded-md text-gray-700 hover:bg-gray-100 transition w-16 h-16"
+              >
+                <FaEdit className="text-gray-700" size={24} />
+                <span style={{ fontSize: '0.6rem' }} className="mt-1">編集する</span>
+              </button>
+              <button
+                onClick={handleDelete}
+                className="flex flex-col items-center justify-center p-2 border border-gray-400 rounded-md text-gray-700 hover:bg-gray-100 transition w-16 h-16"
+              >
+                <FaTrash className="text-gray-700" size={24} />
+                <span style={{ fontSize: '0.6rem' }} className="mt-1">削除する</span>
+              </button>
+            </>
+          )}
+        </div>
       </div>
     </div>
-    </>
   );
 }
 

--- a/front/src/app/components/Canvas.jsx
+++ b/front/src/app/components/Canvas.jsx
@@ -226,7 +226,8 @@ const handleImageClick = (index) => {
   }, [loadedImages]);
 
   return (
-    <div className="flex flex-col items-center pt-5 overflow-y-auto">
+    <div className="flex flex-col items-center md:items-end md:pr-16 pt-5 overflow-y-auto min-h-screen">
+      <div className="w-full max-w-4xl">
       <Stage
         ref={stageRef}
         width={stageWidth}
@@ -234,7 +235,6 @@ const handleImageClick = (index) => {
         scaleX={scale.scaleX}
         scaleY={scale.scaleY}
         onMouseDown={handleStageMouseDown}
-        style={{ border: '1px solid #ccc' }} // 確認用に境界線を追加
       >
         <Layer>
           <Rect
@@ -293,9 +293,10 @@ const handleImageClick = (index) => {
           )}
         </Layer>
       </Stage>
-      <div style={{ marginTop: "20px", display: "flex", flexDirection: "column", alignItems: "center", gap: "10px" }}>
+      </div>
+      <div className="mt-5 flex flex-col items-center gap-4 w-full max-w-4xl">
         {/* ページ移動エリア */}
-        <div style={{ display: "flex", gap: "10px", alignItems: "center" }}>
+        <div className="flex gap-4 items-center justify-center">
           <button
             onClick={() => setCurrentPageIndex(currentPageIndex - 1)}
             disabled={currentPageIndex === 0}

--- a/front/src/app/components/CreateBookFooter.jsx
+++ b/front/src/app/components/CreateBookFooter.jsx
@@ -1,5 +1,3 @@
-// front/src/app/components/CreateBookFooter.jsx
-
 "use client";
 
 import React, { useEffect, useMemo, useRef } from "react";
@@ -10,9 +8,8 @@ import PeopleImages from "./PeopleImages";
 import NatureImages from "./NatureImages";
 import ObjectImages from "./ObjectImages";
 import useCanvasStore from "../../stores/canvasStore";
-import useIsMobile from "@/hooks/useIsMobile"; // カスタムフックをインポート
-import Sidebar from "./Sidebar"; // サイドバーコンポーネントをインポート
-
+import useIsMobile from "@/hooks/useIsMobile";
+import Sidebar from "./Sidebar";
 export default function CreateBookFooter({
   activePanel,
   togglePanel,
@@ -145,7 +142,7 @@ export default function CreateBookFooter({
           ref={panelRef} // パネルに ref を割り当て
           className={`fixed shadow-lg p-4 transition-transform duration-300 bg-white bg-opacity-50 ${
             isMobile
-              ? `left-0 bottom-0 w-full h-1/3 transform ${
+              ? `left-0 bottom-24 w-full h-1/4 transform ${
                   activePanel ? "translate-y-0" : "translate-y-full"
                 }`
               : `top-20 left-20 w-1/4 h-full transform ${
@@ -163,7 +160,7 @@ export default function CreateBookFooter({
       {isMobile ? (
         <footer
           ref={footerRef} // フッターに ref を割り当て
-          className="flex justify-start gap-4 p-4 text-bodyText text-sm bg-white bg-opacity-80 fixed bottom-0 w-full shadow-inner"
+          className="flex justify-center gap-4 p-4 text-bodyText text-sm bg-white bg-opacity-80 fixed bottom-0 w-full shadow-inner"
         >
           <button
             onClick={() => togglePanel("人物")}

--- a/front/src/app/components/CreateBookFooter.jsx
+++ b/front/src/app/components/CreateBookFooter.jsx
@@ -1,3 +1,5 @@
+// front/src/app/components/CreateBookFooter.jsx
+
 "use client";
 
 import { useEffect, useMemo } from "react";
@@ -8,6 +10,8 @@ import PeopleImages from "./PeopleImages";
 import NatureImages from "./NatureImages";
 import ObjectImages from "./ObjectImages";
 import useCanvasStore from "../../stores/canvasStore";
+import useIsMobile from "@/hooks/useIsMobile"; // カスタムフックをインポート
+import Sidebar from "./Sidebar"; // サイドバーコンポーネントをインポート
 
 export default function CreateBookFooter({
   activePanel,
@@ -16,13 +20,12 @@ export default function CreateBookFooter({
   handleUpdateText,
   setBackgroundColor,
 }) {
-
   const handleAddImage = useCanvasStore((state) => state.handleAddImage);
   const pages = useCanvasStore((state) => state.pages);
+  const isMobile = useIsMobile(); // デバイス判定
 
   // 最近使用した背景色を計算
   const recentColors = useMemo(() => {
-    // ページをページ番号の降順にソート（新しい順）
     const sortedPages = [...pages].sort((a, b) => b.pageNumber - a.pageNumber);
     const colors = sortedPages.map((page) => page.backgroundColor);
     const uniqueColors = [];
@@ -68,9 +71,9 @@ export default function CreateBookFooter({
               />
             </div>
             {recentColors.length > 0 && (
-              <div className="flex items-center gap-2">
-                <label>直近で使った色:</label>
-                <div className="flex gap-2">
+              <div className="flex flex-col gap-2">
+                <label>使った色:</label>
+                <div className="flex gap-2 flex-wrap">
                   {recentColors.map((color, index) => (
                     <div
                       key={index}
@@ -123,48 +126,115 @@ export default function CreateBookFooter({
     <>
       {activePanel && (
         <div
-          className="fixed left-0 bottom-0 w-full h-1/3 shadow-lg p-4 transition-transform duration-300"
-          style={{
-            transform: activePanel ? "translateY(0)" : "translateY(100%)",
-            backgroundColor: "rgba(255, 255, 255, 0.8)",
-          }}
+          className={`fixed shadow-lg p-4 transition-transform duration-300 bg-white bg-opacity-50 ${
+            isMobile
+              ? `left-0 bottom-0 w-full h-1/3 transform ${
+                  activePanel ? "translate-y-0" : "translate-y-full"
+                }`
+              : `top-20 left-20 w-1/4.9 h-full transform ${
+                  activePanel ? "translate-x-0" : "-translate-x-full"
+                }`
+          }`}
+          style={{ zIndex: 50 }} // サイドバーより上に表示
         >
           <h2 className="text-lg font-bold mb-4">{activePanel}を選ぶ</h2>
           {renderPanelContent()}
         </div>
       )}
 
-      {/* CREATE-BOOKページ専用のフッター */}
-      <footer
-        className="flex justify-center gap-8 p-4 text-bodyText text-sm"
-        style={{
-          backgroundColor: "rgba(255, 255, 255, 0.8)",
-          position: "fixed",
-          bottom: 0,
-          width: "100%",
-        }}
-      >
-        <button onClick={() => togglePanel("人物")} className="flex flex-col items-center mx-2">
-          <FaUser size={32} className="text-icon" />
-          <span>人物</span>
-        </button>
-        <button onClick={() => togglePanel("自然")} className="flex flex-col items-center mx-2">
-          <FaTree size={32} className="text-icon" />
-          <span>自然</span>
-        </button>
-        <button onClick={() => togglePanel("もの")} className="flex flex-col items-center mx-2">
-          <FaBriefcase size={32} className="text-icon" />
-          <span>もの</span>
-        </button>
-        <button onClick={() => togglePanel("文字")} className="flex flex-col items-center mx-2">
-          <MdOutlineTextFields size={32} className="text-icon" />
-          <span>文字</span>
-        </button>
-        <button onClick={() => togglePanel("背景色")} className="flex flex-col items-center">
-          <MdFormatColorFill size={32} className="text-icon" />
-          <span>背景</span>
-        </button>
-      </footer>
+      {/* スマートフォンの場合、フッターとして表示 */}
+      {isMobile ? (
+        <footer
+          className="flex justify-start gap-4 p-4 text-bodyText text-sm bg-white bg-opacity-80 fixed bottom-0 w-full shadow-inner"
+        >
+          <button
+            onClick={() => togglePanel("人物")}
+            className="flex flex-col items-start gap-1 p-2 rounded-md hover:bg-gray-200"
+            aria-label="人物パネルを開く"
+          >
+            <FaUser size={24} className="text-icon" />
+            <span>人物</span>
+          </button>
+          <button
+            onClick={() => togglePanel("自然")}
+            className="flex flex-col items-start gap-1 p-2 rounded-md hover:bg-gray-200"
+            aria-label="自然パネルを開く"
+          >
+            <FaTree size={24} className="text-icon" />
+            <span>自然</span>
+          </button>
+          <button
+            onClick={() => togglePanel("もの")}
+            className="flex flex-col items-start gap-1 p-2 rounded-md hover:bg-gray-200"
+            aria-label="ものパネルを開く"
+          >
+            <FaBriefcase size={24} className="text-icon" />
+            <span>もの</span>
+          </button>
+          <button
+            onClick={() => togglePanel("文字")}
+            className="flex flex-col items-start gap-1 p-2 rounded-md hover:bg-gray-200"
+            aria-label="文字パネルを開く"
+          >
+            <MdOutlineTextFields size={24} className="text-icon" />
+            <span>文字</span>
+          </button>
+          <button
+            onClick={() => togglePanel("背景色")}
+            className="flex flex-col items-start gap-1 p-2 rounded-md hover:bg-gray-200"
+            aria-label="背景色パネルを開く"
+          >
+            <MdFormatColorFill size={24} className="text-icon" />
+            <span>背景</span>
+          </button>
+        </footer>
+      ) : (
+        // PC/タブレットの場合、サイドバーとして表示
+        <Sidebar>
+          <div className="flex flex-col items-start gap-4">
+            <button
+              onClick={() => togglePanel("人物")}
+              className="flex flex-col items-start w-full gap-2 p-2 rounded-md hover:bg-gray-200"
+              aria-label="人物パネルを開く"
+            >
+              <FaUser size={32} className="text-icon" />
+              <span>人物</span>
+            </button>
+            <button
+              onClick={() => togglePanel("自然")}
+              className="flex flex-col items-start w-full gap-2 p-2 rounded-md hover:bg-gray-200"
+              aria-label="自然パネルを開く"
+            >
+              <FaTree size={32} className="text-icon" />
+              <span>自然</span>
+            </button>
+            <button
+              onClick={() => togglePanel("もの")}
+              className="flex flex-col items-start w-full gap-2 p-2 rounded-md hover:bg-gray-200"
+              aria-label="ものパネルを開く"
+            >
+              <FaBriefcase size={32} className="text-icon" />
+              <span>もの</span>
+            </button>
+            <button
+              onClick={() => togglePanel("文字")}
+              className="flex flex-col items-start w-full gap-2 p-2 rounded-md hover:bg-gray-200"
+              aria-label="文字パネルを開く"
+            >
+              <MdOutlineTextFields size={32} className="text-icon" />
+              <span>文字</span>
+            </button>
+            <button
+              onClick={() => togglePanel("背景色")}
+              className="flex flex-col items-start w-full gap-2 p-2 rounded-md hover:bg-gray-200"
+              aria-label="背景色パネルを開く"
+            >
+              <MdFormatColorFill size={32} className="text-icon" />
+              <span>背景</span>
+            </button>
+          </div>
+        </Sidebar>
+      )}
     </>
   );
 }

--- a/front/src/app/components/ModalManager.jsx
+++ b/front/src/app/components/ModalManager.jsx
@@ -146,7 +146,7 @@ export default function ModalManager() {
 
       resetCanvas();
       closeModal();
-      router.push('/index-books');
+      router.push('/myPage');
     } catch (error) {
       console.error("保存中にエラーが発生しました:", error);
       alert("保存中にエラーが発生しました");

--- a/front/src/app/components/NatureImages.jsx
+++ b/front/src/app/components/NatureImages.jsx
@@ -7,7 +7,7 @@ export default function NatureImages({ onImageSelect }) {
 
   return (
     <div
-      className="grid grid-cols-8 md:grid-cols-3 gap-2 overflow-y-scroll max-h-[250px] md:max-h-[800px] lg:max-h-[700px]"
+      className="grid grid-cols-8 md:grid-cols-3 gap-2 overflow-y-scroll max-h-[175px] md:max-h-[800px] lg:max-h-[700px]"
     >
       {images.map((src, index) => (
         <div key={index} className="w-20 h-20 flex items-center justify-center">

--- a/front/src/app/components/NatureImages.jsx
+++ b/front/src/app/components/NatureImages.jsx
@@ -7,8 +7,7 @@ export default function NatureImages({ onImageSelect }) {
 
   return (
     <div
-      className="grid grid-cols-8 gap-4 overflow-y-scroll"
-      style={{ maxHeight: '250px' }}
+      className="grid grid-cols-8 md:grid-cols-3 gap-2 overflow-y-scroll max-h-[250px] md:max-h-[800px] lg:max-h-[700px]"
     >
       {images.map((src, index) => (
         <div key={index} className="w-20 h-20 flex items-center justify-center">

--- a/front/src/app/components/ObjectImages.jsx
+++ b/front/src/app/components/ObjectImages.jsx
@@ -7,8 +7,7 @@ export default function ObjectImages({ onImageSelect }) {
 
   return (
     <div
-      className="grid grid-cols-8 gap-4 overflow-y-scroll"
-      style={{ maxHeight: '250px' }}
+      className="grid grid-cols-8 md:grid-cols-3 gap-2 overflow-y-scroll max-h-[250px] md:max-h-[800px] lg:max-h-[700px]"
     >
       {images.map((src, index) => (
         <div key={index} className="w-20 h-20 flex items-center justify-center">

--- a/front/src/app/components/ObjectImages.jsx
+++ b/front/src/app/components/ObjectImages.jsx
@@ -7,7 +7,7 @@ export default function ObjectImages({ onImageSelect }) {
 
   return (
     <div
-      className="grid grid-cols-8 md:grid-cols-3 gap-2 overflow-y-scroll max-h-[250px] md:max-h-[800px] lg:max-h-[700px]"
+      className="grid grid-cols-8 md:grid-cols-3 gap-2 overflow-y-scroll max-h-[175px] md:max-h-[800px] lg:max-h-[700px]"
     >
       {images.map((src, index) => (
         <div key={index} className="w-20 h-20 flex items-center justify-center">

--- a/front/src/app/components/PeopleImages.jsx
+++ b/front/src/app/components/PeopleImages.jsx
@@ -7,8 +7,7 @@ export default function PeopleImages({ onImageSelect }) {
 
   return (
     <div
-      className="grid grid-cols-8 gap-4 overflow-y-scroll"
-      style={{ maxHeight: '250px' }}
+      className="grid grid-cols-8 md:grid-cols-3 gap-2 overflow-y-scroll max-h-[250px] md:max-h-[800px] lg:max-h-[1000px]"
     >
       {images.map((src, index) => (
         <div key={index} className="w-20 h-20 flex items-center justify-center">
@@ -19,7 +18,7 @@ export default function PeopleImages({ onImageSelect }) {
             height={48}
             onClick={() => {
               console.log("Image clicked:", src);
-              onImageSelect && onImageSelect(src)
+              onImageSelect && onImageSelect(src);
             }}
           />
         </div>

--- a/front/src/app/components/PeopleImages.jsx
+++ b/front/src/app/components/PeopleImages.jsx
@@ -7,7 +7,7 @@ export default function PeopleImages({ onImageSelect }) {
 
   return (
     <div
-      className="grid grid-cols-8 md:grid-cols-3 gap-2 overflow-y-scroll max-h-[250px] md:max-h-[800px] lg:max-h-[1000px]"
+      className="grid grid-cols-8 md:grid-cols-3 gap-2 overflow-y-scroll max-h-[175px] md:max-h-[800px] lg:max-h-[1000px]"
     >
       {images.map((src, index) => (
         <div key={index} className="w-20 h-20 flex items-center justify-center">

--- a/front/src/app/components/Sidebar.jsx
+++ b/front/src/app/components/Sidebar.jsx
@@ -2,6 +2,7 @@
 
 import React, { forwardRef } from "react";
 
+// Sidebar コンポーネントを forwardRef でラップ
 const Sidebar = forwardRef(({ children }, ref) => {
   return (
     <div
@@ -16,5 +17,8 @@ const Sidebar = forwardRef(({ children }, ref) => {
     </div>
   );
 });
+
+// displayName を設定して ESLint エラーを解消
+Sidebar.displayName = "Sidebar";
 
 export default Sidebar;

--- a/front/src/app/components/Sidebar.jsx
+++ b/front/src/app/components/Sidebar.jsx
@@ -1,0 +1,20 @@
+// front/src/app/components/Sidebar.jsx
+
+"use client";
+
+import React from "react";
+
+export default function Sidebar({ children }) {
+  return (
+    <div
+      className="fixed top-16 left-0 h-full bg-white shadow-lg p-4 opacity-70"
+      style={{ zIndex: 40 }} // 必要に応じて調整
+    >
+      {/* サイドバーのコンテンツ */}
+      <div className="flex flex-col items-center gap-4">
+        {children}
+      </div>
+    </div>
+  );
+}
+

--- a/front/src/app/components/Sidebar.jsx
+++ b/front/src/app/components/Sidebar.jsx
@@ -1,14 +1,13 @@
-// front/src/app/components/Sidebar.jsx
-
 "use client";
 
-import React from "react";
+import React, { forwardRef } from "react";
 
-export default function Sidebar({ children }) {
+const Sidebar = forwardRef(({ children }, ref) => {
   return (
     <div
-      className="fixed top-16 left-0 h-full bg-white shadow-lg p-4 opacity-70"
-      style={{ zIndex: 40 }} // 必要に応じて調整
+      ref={ref} // ref をここに渡す
+      className="fixed top-16 left-0 h-full bg-white shadow-lg p-4 opacity-70 sidebar"
+      style={{ zIndex: 40 }}
     >
       {/* サイドバーのコンテンツ */}
       <div className="flex flex-col items-center gap-4">
@@ -16,5 +15,6 @@ export default function Sidebar({ children }) {
       </div>
     </div>
   );
-}
+});
 
+export default Sidebar;

--- a/front/src/app/components/TextInputCanvas.jsx
+++ b/front/src/app/components/TextInputCanvas.jsx
@@ -45,12 +45,10 @@ function TextInputCanvas({}) {
   };
 
   return (
-    <div
-      className="text-input-canvas overflow-y-scroll"
-      style={{ maxHeight: '250px' }}
-    >
-      <div className="flex flex-wrap">
-        <div className="w-full pr-2 mb-4">
+    <div className="grid overflow-y-scroll max-h-[250px] md:max-h-[800px] lg:max-h-[1000px]">
+      <div className="flex flex-wrap lg:flex-col lg:gap-4 lg:items-start">
+        {/* 入力フィールド */}
+        <div className="w-full mb-4">
           <input
             type="text"
             value={inputText}
@@ -59,31 +57,39 @@ function TextInputCanvas({}) {
             className="border p-2 w-full"
           />
         </div>
-        <div className="flex items-center gap-2">
-          <label>サイズ:</label>
+
+        {/* サイズ選択フィールド */}
+        <div className="w-full flex items-center gap-2 mb-4">
+          <label className="whitespace-nowrap">サイズ : </label>
           <input
             type="number"
             value={fontSize}
             onChange={(e) => setFontSize(Number(e.target.value))}
             placeholder="フォントサイズ"
-            className="border p-2 mr-4"
-            style={{ width: '20%' }}
+            className="border p-2"
+            style={{ width: '80px' }} // 必要に応じてサイズ調整
           />
-          <div className="flex items-center p-4 gap-2">
-            <label>文字色:</label>
-            <input
-              type="color"
-              value={fontColor}
-              onChange={(e) => setFontColor(e.target.value)}
-              className="w-12 h-12"
-            />
-          </div>
+        </div>
+
+        {/* 文字色選択フィールド */}
+        <div className="w-full flex items-center gap-2 mb-4">
+          <label>文字色 : </label>
+          <input
+            type="color"
+            value={fontColor}
+            onChange={(e) => setFontColor(e.target.value)}
+            className="w-12 h-12"
+          />
+        </div>
+
+        {/* ボタン */}
+        <div className="w-full">
           <button
             onClick={handleButtonClick}
-            className="p-2 bg-customButton text-white rounded-md hover:bg-opacity-80 ml-4"
-            style={{ width: '20%' }}
+            className="p-2 bg-customButton text-white rounded-md hover:bg-opacity-80"
+            style={{ width: '80px' }}
           >
-            {selectedText ? 'テキストを更新' : 'キャンバスに追加'}
+            {selectedText ? '更新' : '追加'}
           </button>
         </div>
       </div>

--- a/front/src/app/components/TextInputCanvas.jsx
+++ b/front/src/app/components/TextInputCanvas.jsx
@@ -59,7 +59,7 @@ function TextInputCanvas({}) {
         </div>
 
         {/* サイズ選択フィールド */}
-        <div className="w-full flex items-center gap-2 mb-4">
+        <div className="w-full flex items-center gap-2">
           <label className="whitespace-nowrap">サイズ : </label>
           <input
             type="number"

--- a/front/src/app/index-books/page.jsx
+++ b/front/src/app/index-books/page.jsx
@@ -16,7 +16,7 @@ function BookListPage() {
 
   if (loading)
     return (
-      <div className="flex items-center justify-center h-screen">
+      <div className="flex items-center justify-center min-h-screen">
         <div className="text-center">
           <span className="loading loading-dots loading-lg"></span>
           <p className="mt-4 text-lg font-semibold">ページを読み込んでいます...</p>
@@ -32,8 +32,8 @@ function BookListPage() {
     );
 
   return (
-    <div className="flex flex-col items-center justify-center p-8 space-y-8">
-      <h1 className="text-3xl font-bold mb-6">みんなの絵本</h1>
+    <div className="flex flex-col items-center justify-center p-8 space-y-8 pb-32">
+      <h1 className="text-3xl font-bold mb-4">みんなの絵本</h1>
       <BookList books={publishedBooks} pageType="bookListPage" />
     </div>
   );

--- a/front/src/app/myPage/page.jsx
+++ b/front/src/app/myPage/page.jsx
@@ -57,8 +57,8 @@ function MyPage() {
     );
 
   return (
-    <div className="flex flex-col items-center justify-center p-8 space-y-8">
-      <h1 className="text-3xl font-bold mb-6">{userName}さんの絵本</h1>
+    <div className="flex flex-col items-center justify-center p-8 space-y-8 pb-32">
+      <h1 className="text-3xl font-bold mb-4">{userName}さんの絵本</h1>
       <BookList books={myBooks} pageType="myPage" />
     </div>
   );

--- a/front/src/app/page.jsx
+++ b/front/src/app/page.jsx
@@ -20,7 +20,7 @@ function App() {
         style={{ backgroundColor: "rgba(255, 255, 255, 0.5)" }}
       >
         <div className="flex items-center mb-2">
-          <h2 className="text-2xl font-bold text-heading">チュートリアル</h2>
+          <h2 className="text-2xl font-bold text-heading">チュートリアル ( ※未実装です )</h2>
           <FaInfoCircle size={32} className="ml-2 text-icon" />
         </div>
         <p className="text-sm text-bodyText mb-4">再生して使い方を見る</p>
@@ -54,6 +54,7 @@ function App() {
           imageSrc="home/index.jpg"
           altText="Library"
           additionalInfo="この画面をクリックすると絵本の一覧が見れます"
+          path="/index-books"
         />
         <BookCard
           title="絵本を作ってみる"
@@ -61,6 +62,7 @@ function App() {
           imageSrc="home/make.jpg"
           altText="Create Library"
           additionalInfo="絵本作成にはユーザー登録が必要です"
+          path="/create-book"
         />
       </div>
     </div>

--- a/front/src/hooks/useIsMobile.js
+++ b/front/src/hooks/useIsMobile.js
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react';
+
+export default function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    // 関数を定義してウィンドウ幅に基づいて状態を更新
+    const updateIsMobile = () => {
+      setIsMobile(window.innerWidth < 768); // ブレークポイントを必要に応じて調整
+    };
+
+    // イベントリスナーを追加
+    window.addEventListener('resize', updateIsMobile);
+
+    // 初期チェック
+    updateIsMobile();
+
+    // クリーンアップ
+    return () => window.removeEventListener('resize', updateIsMobile);
+  }, []);
+
+  return isMobile;
+}


### PR DESCRIPTION
Closes #177

## 概要
現在、画面サイズに関係なくfooterからスタンプや文字を追加していたため、UI/UXに問題がありました。そのため、画面のサイズが大きい場合はfooterではなくサイドバーに変更しました。

## やったこと
- **スタンプおよび文字追加機能の移行**
  - Footerからサイドバーへのスタンプおよび文字追加機能を移行しました。
- **レスポンシブデザインの調整**
  - 画面サイズに応じてスタンプや文字の表示位置をfooterからサイドバーに変更するため、レスポンシブデザインを調整しました。
- **スタイルの修正**
  - サイドバーのデザインを調整し、ユーザビリティを向上させるためにCSSを修正しました。
- **コードの最適化**
  - 関連するコンポーネントおよびスタイルシートを整理し、コードの可読性と保守性を向上させました。

## やらないこと
- スタンプや文字の新規追加機能の実装
- サイドバーの完全なリデザイン

## できるようになること（ユーザ目線）
- **操作性の向上**
  - 大画面でのスタンプや文字の追加がサイドバーから行えるようになり、操作が直感的かつ快適になります。
- **UIの改善**
  - UIが整理され、ユーザーが必要な機能に迅速にアクセスできるようになります。

## できなくなること（ユーザ目線）
- **なし**
