### PR TITLE
ダブルクリックでテキスト追加は、詳細ページでは無効化

### DIFF
--- a/front/src/app/components/BookDetailPage.jsx
+++ b/front/src/app/components/BookDetailPage.jsx
@@ -85,6 +85,7 @@ function BookDetailPage() {
               isReadOnly={true}
               allowAddPage={false}
               showUndoButton={false}
+              allowAddText={false}
             />
           </div>
         )}

--- a/front/src/app/components/Canvas.jsx
+++ b/front/src/app/components/Canvas.jsx
@@ -9,7 +9,7 @@ import { useRouter } from 'next/navigation';
 import ModalManager from './ModalManager';
 import useIsMobile from '../../hooks/useIsMobile'; // 必要に応じてパスを調整
 
-function Canvas({ showActionButtons, isReadOnly, allowAddPage, showUndoButton, setPanel, activePanel }) {
+function Canvas({ showActionButtons, isReadOnly, allowAddPage, showUndoButton, setPanel, allowAddText = true }) {
   const {
     selectedTextIndex,
     selectedImageIndex,
@@ -339,7 +339,7 @@ function Canvas({ showActionButtons, isReadOnly, allowAddPage, showUndoButton, s
             scaleX={scale.scaleX}
             scaleY={scale.scaleY}
             onMouseDown={handleStageMouseDown}
-            onDblClick={handleStageDblClick} // ステージのダブルクリックイベント
+            onDblClick={allowAddText ? handleStageDblClick : undefined} // 条件付きでダブルクリックイベントを設定
           >
             <Layer>
               <Rect

--- a/front/src/app/components/Canvas.jsx
+++ b/front/src/app/components/Canvas.jsx
@@ -4,7 +4,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Stage, Layer, Rect, Text, Transformer, Image as KonvaImage } from 'react-konva';
 import useCanvasStore from '../../stores/canvasStore';
-import { FaChevronCircleLeft, FaChevronCircleRight, FaUndo } from "react-icons/fa";
+import { FaChevronCircleLeft, FaChevronCircleRight, FaUndo, FaPlus } from "react-icons/fa";
 import { useRouter } from 'next/navigation';
 import ModalManager from './ModalManager';
 import useIsMobile from '../../hooks/useIsMobile'; // 必要に応じてパスを調整
@@ -446,13 +446,19 @@ function Canvas({ showActionButtons, isReadOnly, allowAddPage, showUndoButton, s
         <div className="flex flex-col items-center gap-4 w-full max-w-4xl mx-auto mb-28">
           {/* ページ移動エリア */}
           <div className="flex gap-4 items-center justify-center w-full">
-            <button
-              onClick={() => setCurrentPageIndex(currentPageIndex - 1)}
-              disabled={currentPageIndex === 0}
-              className="p-2 text-bodyText flex items-center justify-center"
-            >
-              <FaChevronCircleLeft size={32} />
-            </button>
+            {/* 前のページボタンとラベル */}
+            <div className="flex flex-col items-center">
+              <button
+                onClick={() => setCurrentPageIndex(currentPageIndex - 1)}
+                disabled={currentPageIndex === 0}
+                className={`p-2 flex items-center justify-center rounded-full transition-transform duration-200 ease-in-out transform hover:-translate-y-1 active:translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed text-bodyText`}
+                aria-label="前のページ"
+              >
+                <FaChevronCircleLeft size={32} />
+              </button>
+              <span className="mt-1 text-sm text-bodyText">前のページ</span>
+            </div>
+
             {/* 現在のページ / 総ページ数 */}
             <div className="flex items-center space-x-2">
               <input
@@ -466,38 +472,55 @@ function Canvas({ showActionButtons, isReadOnly, allowAddPage, showUndoButton, s
                     setCurrentPageIndex(page); // ページを設定
                   }
                 }}
-                className="w-16 p-1 text-center border rounded-md border-gray-300"
+                className="w-16 p-1 text-center border rounded-md border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 text-bodyText"
               />
               <span className="text-bodyText font-semibold">/ {pages.length}</span>
             </div>
-            <button
-              onClick={() => {
-                if (currentPageIndex < pages.length - 1) {
-                  setCurrentPageIndex(currentPageIndex + 1);
-                } else {
-                  if (allowAddPage) { // ページ追加が許可されている場合のみ追加
-                    addPage();
-                  } else {
-                    alert("このページではページの追加はできません。");
-                  }
-                }
-              }}
-              className={`p-2 text-bodyText flex items-center justify-center rounded-full transition-all duration-300 ease-in-out hover:text-gray-700 hover:bg-gray-200 hover:shadow-md ${
-                !allowAddPage && currentPageIndex >= pages.length - 1 ? 'cursor-not-allowed opacity-50' : ''
-              }`}
-              disabled={!allowAddPage && currentPageIndex >= pages.length - 1} // ページ追加が許可されていないかつ最後のページの場合に無効化
-            >
-              <FaChevronCircleRight size={32} />
-            </button>
-            {/* Undo ボタン */}
-            {showUndoButton && (
+
+            {/* 次のページボタンとラベル */}
+            <div className="flex flex-col items-center">
               <button
-                onClick={() => undo()}
-                disabled={history.length === 0}
-                className={`p-2 text-gray-900 flex items-center justify-center rounded-full transition-all duration-300 ease-in-out hover:text-gray-700 hover:bg-gray-200 hover:shadow-md ${history.length === 0 ? 'opacity-50 cursor-not-allowed' : ''}`}
+                onClick={() => {
+                  if (currentPageIndex < pages.length - 1) {
+                    setCurrentPageIndex(currentPageIndex + 1);
+                  }
+                }}
+                className={`p-2 flex items-center justify-center rounded-full transition-transform duration-200 ease-in-out transform hover:-translate-y-1 active:translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed text-bodyText`}
+                disabled={currentPageIndex >= pages.length - 1 && !allowAddPage}
+                aria-label="次のページ"
               >
-                <FaUndo size={32} />
+                <FaChevronCircleRight size={32} />
               </button>
+              <span className="mt-1 text-sm text-bodyText">次のページ</span>
+            </div>
+
+            {/* 「+」ボタンの追加とラベル */}
+            {allowAddPage && (
+              <div className="flex flex-col items-center">
+                <button
+                  onClick={addPage}
+                  className={`p-2 flex items-center justify-center rounded-full transition-transform duration-200 ease-in-out transform hover:-translate-y-1 active:translate-y-0.5 text-bodyText`}
+                  aria-label="ページを追加"
+                >
+                  <FaPlus size={32} />
+                </button>
+                <span className="mt-1 text-sm text-bodyText">ページを追加</span>
+              </div>
+            )}
+
+            {/* Undo ボタンとラベル */}
+            {showUndoButton && (
+              <div className="flex flex-col items-center">
+                <button
+                  onClick={() => undo()}
+                  disabled={history.length === 0}
+                  className={`p-2 flex items-center justify-center rounded-full transition-transform duration-200 ease-in-out transform hover:-translate-y-1 active:translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed text-bodyText`}
+                  aria-label="1つ戻る"
+                >
+                  <FaUndo size={32} />
+                </button>
+                <span className="mt-1 text-sm text-bodyText">1つ戻る</span>
+              </div>
             )}
           </div>
           {/* ModalManager を中央に配置 */}

--- a/front/src/app/components/CreateBookFooter.jsx
+++ b/front/src/app/components/CreateBookFooter.jsx
@@ -58,13 +58,13 @@ export default function CreateBookFooter({
         return <ObjectImages onImageSelect={(src) => handleImageSelect(src, 'もの')} />;
       case "背景色":
         return (
-          <div className="flex flex-col p-4 gap-4">
+          <div className="flex flex-col p-4 gap-4 overflow-y-scroll max-h-[125px] md:max-h-[800px] lg:max-h-[1000px]">
             <div className="flex items-center gap-2">
               <label>背景色を選択:</label>
               <input
                 type="color"
                 onChange={(e) => handleBackgroundColorChange(e.target.value)}
-                className="w-12 h-12"
+                className="w-12 h-12 cursor-pointer"
               />
             </div>
             {recentColors.length > 0 && (

--- a/front/src/app/components/NatureImages.jsx
+++ b/front/src/app/components/NatureImages.jsx
@@ -18,7 +18,6 @@ export default function NatureImages({ onImageSelect }) {
             height={48}
             className="cursor-pointer"
             onClick={() => {
-              console.log("Image clicked:", src);
               onImageSelect && onImageSelect(src, "自然"); // カテゴリを渡す
             }}
           />

--- a/front/src/app/components/NatureImages.jsx
+++ b/front/src/app/components/NatureImages.jsx
@@ -16,6 +16,7 @@ export default function NatureImages({ onImageSelect }) {
             alt={`Person ${index + 1}`}
             width={48}
             height={48}
+            className="cursor-pointer"
             onClick={() => {
               console.log("Image clicked:", src);
               onImageSelect && onImageSelect(src, "自然"); // カテゴリを渡す

--- a/front/src/app/components/ObjectImages.jsx
+++ b/front/src/app/components/ObjectImages.jsx
@@ -16,6 +16,7 @@ export default function ObjectImages({ onImageSelect }) {
             alt={`Person ${index + 1}`}
             width={48}
             height={48}
+            className="cursor-pointer"
             onClick={() => {
               console.log("Image clicked:", src);
               onImageSelect && onImageSelect(src, "もの");

--- a/front/src/app/components/ObjectImages.jsx
+++ b/front/src/app/components/ObjectImages.jsx
@@ -18,7 +18,6 @@ export default function ObjectImages({ onImageSelect }) {
             height={48}
             className="cursor-pointer"
             onClick={() => {
-              console.log("Image clicked:", src);
               onImageSelect && onImageSelect(src, "もの");
             }}
           />

--- a/front/src/app/components/PeopleImages.jsx
+++ b/front/src/app/components/PeopleImages.jsx
@@ -16,6 +16,7 @@ export default function PeopleImages({ onImageSelect }) {
             alt={`Person ${index + 1}`}
             width={48}
             height={48}
+            className="cursor-pointer"
             onClick={() => {
               console.log("Image clicked:", src);
               onImageSelect && onImageSelect(src, "人物");

--- a/front/src/app/components/PeopleImages.jsx
+++ b/front/src/app/components/PeopleImages.jsx
@@ -18,7 +18,6 @@ export default function PeopleImages({ onImageSelect }) {
             height={48}
             className="cursor-pointer"
             onClick={() => {
-              console.log("Image clicked:", src);
               onImageSelect && onImageSelect(src, "人物");
             }}
           />

--- a/front/src/app/components/TextInputCanvas.jsx
+++ b/front/src/app/components/TextInputCanvas.jsx
@@ -123,7 +123,7 @@ function TextInputCanvas() {
             type="color"
             value={fontColor}
             onChange={handleFontColorChange}
-            className="w-12 h-12"
+            className="w-12 h-12 cursor-pointer"
           />
         </div>
 

--- a/front/src/app/create-book/page.jsx
+++ b/front/src/app/create-book/page.jsx
@@ -74,6 +74,7 @@ export default function CreateBookPage() {
           onComplete={onComplete}
           onSaveDraft={onSaveDraft}
           showActionButtons={true}
+          showUndoButton={true}
           allowAddPage={true}
           setPanel={setPanel}
           togglePanel={togglePanel}


### PR DESCRIPTION
Closes #

## 概要
Canvasコンポーネントに対して、ユーザー体験の向上と機能拡張を目的とした複数の改善点を実装します。これには、ページ操作の改善、キーボードショートカットの追加、UIの調整、特定ページでの機能制限、およびレイヤー機能の導入が含まれます。

## やったこと
<!-- このプルリクで何をしたのか？ -->
- [x] ページの追加ボタンを作成
- [x] 「＞ボタン」と「＜ボタン」のレイアウト統一
- [x] 選択したテキストや画像要素をコピー＆ペーストできるように、Ctrl+CおよびCtrl+Vのショートカットを実装する
- [x] 要素選択時にカーソルを指のアイコンに変更し、ユーザーに選択可能であることを視覚的に示す
- [x] モバイルデバイスでの表示において、背景色選択欄の幅を縮小し、画面スペースを有効活用する
- [x] ダブルクリックによる文字追加機能を、編集ページと新規作成ページのみに限定し、一覧ページでは非表示にする

関連ISSUE
#186