### PR TITLE
idがあると登録できないため削除

### DIFF
--- a/front/src/app/components/ModalManager.jsx
+++ b/front/src/app/components/ModalManager.jsx
@@ -90,7 +90,6 @@ export default function ModalManager() {
         page.pageElements.forEach((element) => {
           if (element.elementType === 'text') {
             pageElements.push({
-              id: element.id,
               element_type: 'text', // スネークケースで送信
               text: element.text,
               font_size: element.fontSize,
@@ -103,7 +102,6 @@ export default function ModalManager() {
             });
           } else if (element.elementType === 'image') {
             pageElements.push({
-              id: element.id,
               element_type: 'image', // スネークケースで送信
               src: element.src,
               position_x: element.positionX,


### PR DESCRIPTION
  pageElements.push({
    id: element.id,            
pageElements.push({
   id: element.id,

なんのためのコードでいつ記載したか記憶にないが、これによって保存できないため削除。