### PR TITLE
【エラー】空白テキストの扱い

### DIFF
--- a/front/src/app/components/BookDetailPage.jsx
+++ b/front/src/app/components/BookDetailPage.jsx
@@ -64,7 +64,7 @@ function BookDetailPage() {
     try {
       await axiosInstance.delete(`/api/v1/books/${bookId}`);
       alert("絵本を削除しました。");
-      router.push("/index-books"); // 削除後にリスト画面にリダイレクト
+      router.push("/myPage"); // 削除後にリスト画面にリダイレクト
     } catch (error) {
       console.error("絵本の削除に失敗しました:", error);
       alert("絵本の削除中にエラーが発生しました。");

--- a/front/src/app/components/ModalManager.jsx
+++ b/front/src/app/components/ModalManager.jsx
@@ -84,34 +84,37 @@ export default function ModalManager() {
       // ページの更新または新規作成
       for (const page of pages) {
         // page_elements の構築
-        const pageElements = [];
-
-        // テキスト要素を page_elements に変換
-        page.pageElements.forEach((element) => {
-          if (element.elementType === 'text') {
-            pageElements.push({
-              element_type: 'text', // スネークケースで送信
-              text: element.text,
-              font_size: element.fontSize,
-              font_color: element.fontColor,
-              position_x: element.positionX,
-              position_y: element.positionY,
-              rotation: element.rotation || 0,
-              scale_x: element.scaleX || 1,
-              scale_y: element.scaleY || 1,
-            });
-          } else if (element.elementType === 'image') {
-            pageElements.push({
-              element_type: 'image', // スネークケースで送信
-              src: element.src,
-              position_x: element.positionX,
-              position_y: element.positionY,
-              rotation: element.rotation || 0,
-              scale_x: element.scaleX || 1,
-              scale_y: element.scaleY || 1,
-            });
-          }
-        });
+        const pageElements = page.pageElements
+          // 空のテキスト要素を除外
+          .filter(el => !(el.elementType === 'text' && (!el.text || el.text.trim() === "")))
+          // 必要なフィールドに変換
+          .map(el => {
+            if (el.elementType === 'text') {
+              return {
+                element_type: 'text',
+                text: el.text || null, // 空の場合は null に設定
+                font_size: el.fontSize,
+                font_color: el.fontColor,
+                position_x: el.positionX,
+                position_y: el.positionY,
+                rotation: el.rotation || 0,
+                scale_x: el.scaleX || 1,
+                scale_y: el.scaleY || 1,
+              };
+            } else if (el.elementType === 'image') {
+              return {
+                element_type: 'image',
+                src: el.src,
+                position_x: el.positionX,
+                position_y: el.positionY,
+                rotation: el.rotation || 0,
+                scale_x: el.scaleX || 1,
+                scale_y: el.scaleY || 1,
+              };
+            }
+            return null; // 他のタイプがあれば適宜処理
+          })
+          .filter(el => el !== null); // 不要な null を除外
 
         // page_characters の構築（今後本リリースで修正していく）
         const pageCharacters = page.page_characters || [];


### PR DESCRIPTION
Closes #192

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
現在、書籍のページを作成する際に、elementType が "text" のページ要素で text フィールドが空 ("") の場合、サーバー側でバリデーションエラー (422 Unprocessable Content) が発生しています。これにより、ページの作成が失敗しています。
そのため、 elementType が "text" のページ要素において、text フィールドが空の場合、その要素をリクエストから除外し、サーバー側のバリデーションエラーを回避します。

## やったこと
<!-- このプルリクで何をしたのか？ -->
- ModalManager コンポーネントの修正
  - handleModalSave 関数内で、ページ要素をリクエストに含める前に空のテキスト要素をフィルタリングするロジックを追加する。
  - pageElements をマッピングする際に、空のテキスト要素を除外し、必要に応じて text を null に設定する。
- マイページで編集や削除操作を行った後、ユーザーを自動的にマイページにリダイレクトするように設定する

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- なし

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- なし