### PR TITLE
画像のコピペ時にサイズなどを引き継ぐ

### DIFF
--- a/front/src/app/components/Canvas.jsx
+++ b/front/src/app/components/Canvas.jsx
@@ -234,7 +234,7 @@ function Canvas({
             const newImage = {
               ...elementToPaste,
             };
-            handleAddImage(newImage.src, newImage.imageCategory)
+            handleAddImage({ ...newImage })
               .then((newIndex) => {
                 setSelectedImageIndex(newIndex);
                 setPanel(newImage.imageCategory || '画像');
@@ -248,7 +248,6 @@ function Canvas({
         }
         return;
       }
-
       // 既存のキーイベント（Backspace, Undo）
       if (editingTextIndex === null) {
         if (e.key === 'Backspace') {

--- a/front/src/app/components/CreateBookFooter.jsx
+++ b/front/src/app/components/CreateBookFooter.jsx
@@ -90,7 +90,16 @@ export default function CreateBookFooter({
   };
 
   const handleImageSelect = (src, category) => {
-    handleAddImage(src, category);
+    const imageData = {
+      src,
+      imageCategory: category,
+      positionX: 100,
+      positionY: 100,
+      rotation: 0,
+      scaleX: 0.5,
+      scaleY: 0.5,
+    };
+    handleAddImage(imageData);
   };
 
   // アイコンデータ

--- a/front/src/stores/canvasStore.jsx
+++ b/front/src/stores/canvasStore.jsx
@@ -54,11 +54,11 @@ const useCanvasStore = create((set, get) => ({
   },
 
   // 画像の追加（handleAddImage）
-  handleAddImage: (imageSrc, category) => {
+  handleAddImage: (imageData) => {
     return new Promise((resolve, reject) => {
       get().pushToHistory();
       const img = new window.Image();
-      img.src = imageSrc;
+      img.src = imageData.src;
       img.onload = () => {
         set((state) => {
           const currentPage = state.pages[state.currentPageIndex];
@@ -68,13 +68,13 @@ const useCanvasStore = create((set, get) => ({
           }
           const newImageElement = {
             elementType: 'image',
-            src: imageSrc,
-            positionX: 100, // 初期位置を調整
-            positionY: 100,
-            rotation: 0,
-            scaleX: 0.5, // スケールファクターとして初期化
-            scaleY: 0.5,
-            imageCategory: category,
+            src: imageData.src,
+            positionX: imageData.positionX || 100,
+            positionY: imageData.positionY || 100,
+            rotation: imageData.rotation || 0,
+            scaleX: imageData.scaleX || 0.5,
+            scaleY: imageData.scaleY || 0.5,
+            imageCategory: imageData.imageCategory || 'default',
             id: get().generateUniqueId(),
           };
           const updatedPageElements = [...currentPage.pageElements, newImageElement];
@@ -86,12 +86,11 @@ const useCanvasStore = create((set, get) => ({
           set({ pages: updatedPages });
           return { pages: updatedPages };
         });
-        // 新しく追加された画像のインデックスを返す
         const newIndex = get().pages[get().currentPageIndex].pageElements.length - 1;
         resolve(newIndex);
       };
       img.onerror = () => {
-        console.error("画像の読み込みに失敗しました:", imageSrc);
+        console.error("画像の読み込みに失敗しました:", imageData.src);
         reject(new Error("画像の読み込みに失敗しました。"));
       };
     });


### PR DESCRIPTION
Closes #194

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
handleAddImage 関数を imageData オブジェクトを受け取るように変更し、画像の追加処理を統一しました。これにより、コピーペーストおよびトグルからの画像追加時にエラーが発生しなくなります。

## やったこと
<!-- このプルリクで何をしたのか？ -->
- [x] canvasStore.jsx 内の handleAddImage 関数を修正し、imageData オブジェクトを引数として受け取るように変更。
- [x] CreateBookFooter.jsx の handleImageSelect 関数を修正し、handleAddImage に imageData オブジェクトを渡すように変更。
- [x] 画像のコピーペースト処理部分を修正し、imageData オブジェクトを正しく渡すように変更。
- [x] PeopleImages.jsx、NatureImages.jsx、ObjectImages.jsx コンポーネントにおける onImageSelect の呼び出しをオブジェクト形式に対応。

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- コピーペーストで画像を追加する際にサイズや位置などのプロパティが正しく反映されます。

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- なし

