### PR TITLE
【エラー】マイページへのアクセス時に、JWTアクセストークンの有効期限切れ

### DIFF
--- a/front/src/api/axios.js
+++ b/front/src/api/axios.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import useAuthStore from '@/stores/authStore';
 
 const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
@@ -12,11 +13,13 @@ const axiosInstance = axios.create({
 // リクエストインターセプターを追加して、Authorization ヘッダーを自動設定
 axiosInstance.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem('access_token');
+    const { accessToken } = useAuthStore.getState();
     const excludeUrls = ['/api/v1/auth/sign_in', '/api/v1/auth/sign_up', '/api/v1/auth/refresh'];
-    if (token && !excludeUrls.includes(config.url)) {
-      config.headers['Authorization'] = `Bearer ${token}`;
+    if (accessToken && !excludeUrls.includes(config.url)) {
+      config.headers['Authorization'] = `Bearer ${accessToken}`;
       console.log('Authorization Header Set:', config.headers['Authorization']);
+    } else {
+      console.log('No Authorization Header Set for:', config.url);
     }
     return config;
   },
@@ -31,31 +34,35 @@ axiosInstance.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
     const refreshUrl = '/api/v1/auth/refresh';
+    console.log('Response error:', error.response?.status, originalRequest.url);
+
     if (
       error.response &&
       error.response.status === 401 &&
       !originalRequest._retry &&
-      originalRequest.url !== refreshUrl
+      !originalRequest.url.includes(refreshUrl)
     ) {
       originalRequest._retry = true;
       try {
-        const refreshToken = localStorage.getItem('refresh_token');
+        const { refreshToken } = useAuthStore.getState();
+        console.log('Attempting to refresh token with:', refreshToken);
         if (refreshToken) {
           const response = await axiosInstance.post(refreshUrl, {
             refresh_token: refreshToken,
           });
           const newAccessToken = response.data.access_token;
-          console.log('New Access Token:', newAccessToken);
-          localStorage.setItem('access_token', newAccessToken);
-          axiosInstance.defaults.headers['Authorization'] = `Bearer ${newAccessToken}`;
+          console.log('New Access Token obtained:', newAccessToken);
+          // 新しいアクセストークンをストアに設定
+          useAuthStore.getState().setAccessToken(newAccessToken);
+          // 元のリクエストのAuthorizationヘッダーを更新
           originalRequest.headers['Authorization'] = `Bearer ${newAccessToken}`;
+          console.log('Retrying original request with new token:', newAccessToken);
           return axiosInstance(originalRequest);
         }
       } catch (refreshError) {
         console.error('リフレッシュトークンの更新に失敗しました:', refreshError);
-        // リフレッシュトークンの更新に失敗した場合、ユーザーをログアウトさせる処理
-        localStorage.removeItem('access_token');
-        localStorage.removeItem('refresh_token');
+        // リフレッシュトークンの更新に失敗した場合、ストアをリセットしてログアウト
+        useAuthStore.getState().logout();
         window.location.href = '/login';
         return Promise.reject(refreshError);
       }


### PR DESCRIPTION
Closes #196

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- マイページへのアクセス時に、JWTアクセストークンの有効期限切れによる500 Internal Server Errorが発生する問題を解決するために、バックエンドとフロントエンドのトークン管理およびエラーハンドリングを修正しました。これにより、アクセストークンの期限切れ時にリフレッシュトークンを使用して新しいアクセストークンを取得し、再試行が正常に行われるようにしました。

## やったこと
<!-- このプルリクで何をしたのか？ -->
- [ ]  バックエンドのApplicationControllerにJWTエラーハンドリングを追加し、500 Internal Server Errorから401 Unauthorizedに変更
- [x]  フロントエンドのAxiosインスタンスを修正し、Zustandストアからトークンを取得・設定するように変更
- [x]  マイページコンポーネントから手動でlocalStorageからuserNameを取得する部分を削除
- [ ] Zustandストアのトークン管理ロジックを確認・修正
- [x]  ログイン処理で取得したトークンをZustandストアに正しく設定するよう修正

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- なし

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- なし