### PR TITLE
【バク】ページ更新時に消したエレメントが消えてない問題

### DIFF
--- a/back/app/controllers/api/v1/pages_controller.rb
+++ b/back/app/controllers/api/v1/pages_controller.rb
@@ -54,7 +54,7 @@ class Api::V1::PagesController < ApplicationController
       :page_number,
       :background_color,
       page_elements_attributes: [
-        :id,
+        :id,:_destroy,
         :element_type, :text, :src, :font_size, :font_color,
         :position_x, :position_y, :rotation, :scale_x, :scale_y
       ],

--- a/front/src/app/components/ModalManager.jsx
+++ b/front/src/app/components/ModalManager.jsx
@@ -79,10 +79,16 @@ export default function ModalManager() {
         console.log(`New book created with id: ${newBookId}`);
       }
 
-      console.log("Pages before saving:", pages);
-
       // ページの更新または新規作成
       for (const page of pages) {
+
+        // 削除対象の要素に _destroy フラグを付与
+        const elementsToDelete = page.elementsToDelete || [];
+        const deletedElements = elementsToDelete.map(el => ({
+          id: el.id,
+          _destroy: true,
+        }));
+
         // page_elements の構築
         const pageElements = page.pageElements
           // 空のテキスト要素を除外
@@ -100,6 +106,7 @@ export default function ModalManager() {
                 rotation: el.rotation || 0,
                 scale_x: el.scaleX || 1,
                 scale_y: el.scaleY || 1,
+                _destroy: false,
               };
             } else if (el.elementType === 'image') {
               return {
@@ -110,11 +117,15 @@ export default function ModalManager() {
                 rotation: el.rotation || 0,
                 scale_x: el.scaleX || 1,
                 scale_y: el.scaleY || 1,
+                _destroy: false,
               };
             }
             return null; // 他のタイプがあれば適宜処理
           })
           .filter(el => el !== null); // 不要な null を除外
+
+        // 全ての要素を統合
+        const allPageElements = [...pageElements, ...deletedElements];
 
         // page_characters の構築（今後本リリースで修正していく）
         const pageCharacters = page.page_characters || [];
@@ -124,7 +135,7 @@ export default function ModalManager() {
             book_id: newBookId,
             page_number: page.pageNumber,
             background_color: page.backgroundColor || '#ffffff',
-            page_elements_attributes: pageElements,
+            page_elements_attributes: allPageElements,
             page_characters_attributes: pageCharacters,
           },
         };

--- a/front/src/app/components/NatureImages.jsx
+++ b/front/src/app/components/NatureImages.jsx
@@ -7,7 +7,7 @@ export default function NatureImages({ onImageSelect }) {
 
   return (
     <div
-      className="grid grid-cols-8 md:grid-cols-3 gap-2 overflow-y-scroll max-h-[125px] md:max-h-[800px] lg:max-h-[700px]"
+      className="grid grid-cols-8 md:grid-cols-3 gap-2 overflow-y-scroll max-h-[125px] md:max-h-[500px] lg:max-h-[800px]"
     >
       {images.map((src, index) => (
         <div key={index} className="w-20 h-20 flex items-center justify-center">

--- a/front/src/app/components/ObjectImages.jsx
+++ b/front/src/app/components/ObjectImages.jsx
@@ -7,7 +7,7 @@ export default function ObjectImages({ onImageSelect }) {
 
   return (
     <div
-      className="grid grid-cols-8 md:grid-cols-3 gap-2 overflow-y-scroll max-h-[125px] md:max-h-[800px] lg:max-h-[700px]"
+      className="grid grid-cols-8 md:grid-cols-3 gap-2 overflow-y-scroll max-h-[125px] md:max-h-[500px] lg:max-h-[800px]"
     >
       {images.map((src, index) => (
         <div key={index} className="w-20 h-20 flex items-center justify-center">

--- a/front/src/app/components/PeopleImages.jsx
+++ b/front/src/app/components/PeopleImages.jsx
@@ -7,7 +7,7 @@ export default function PeopleImages({ onImageSelect }) {
 
   return (
     <div
-      className="grid grid-cols-8 md:grid-cols-3 gap-2 overflow-y-scroll max-h-[125px] md:max-h-[800px] lg:max-h-[1000px]"
+      className="grid grid-cols-8 md:grid-cols-3 gap-2 overflow-y-scroll max-h-[125px] md:max-h-[500px] lg:max-h-[800px]"
     >
       {images.map((src, index) => (
         <div key={index} className="w-20 h-20 flex items-center justify-center">

--- a/front/src/stores/canvasStore.jsx
+++ b/front/src/stores/canvasStore.jsx
@@ -12,7 +12,9 @@ const useCanvasStore = create((set, get) => ({
       backgroundColor: '#ffffff',
       pageElements: [],
       pageCharacters: [],
+      elementsToDelete: [],
       id: null,
+      elementsToDelete: [],
     },
   ],
   currentPageIndex: 0,
@@ -129,15 +131,23 @@ const useCanvasStore = create((set, get) => ({
         console.error("現在のページが見つかりません。");
         return {};
       }
+      const element = currentPage.pageElements[index];
+      if (element && element.id) {
+        // 既存の要素を削除対象リストに追加
+        const updatedElementsToDelete = [...currentPage.elementsToDelete, { id: element.id }];
+        currentPage.elementsToDelete = updatedElementsToDelete; // ページに直接設定
+      }
       const updatedElements = currentPage.pageElements.filter((el, i) => !(i === index && el.elementType === 'image'));
       const updatedPages = [...state.pages];
       updatedPages[state.currentPageIndex] = {
         ...currentPage,
         pageElements: updatedElements,
+        elementsToDelete: currentPage.elementsToDelete, // 更新済み
       };
       return { pages: updatedPages };
     });
   },
+
   setSelectedImageIndex: (index) => set({ selectedImageIndex: index }),
 
   // テキストの追加
@@ -204,11 +214,18 @@ const useCanvasStore = create((set, get) => ({
         console.error("現在のページが見つかりません。");
         return {};
       }
+      const element = currentPage.pageElements[index];
+      if (element && element.id) {
+        // 既存の要素を削除対象リストに追加
+        const updatedElementsToDelete = [...currentPage.elementsToDelete, { id: element.id }];
+        currentPage.elementsToDelete = updatedElementsToDelete; // ページに直接設定
+      }
       const updatedElements = currentPage.pageElements.filter((el, i) => !(i === index && el.elementType === 'text'));
       const updatedPages = [...state.pages];
       updatedPages[state.currentPageIndex] = {
         ...currentPage,
         pageElements: updatedElements,
+        elementsToDelete: currentPage.elementsToDelete, // 更新済み
       };
       return { pages: updatedPages };
     });
@@ -227,6 +244,7 @@ const useCanvasStore = create((set, get) => ({
         pageElements: [],
         pageCharacters: [],
         id: null,
+        elementsToDelete: [],
       };
       const updatedPages = [...state.pages, newPage];
       return {
@@ -258,6 +276,7 @@ const useCanvasStore = create((set, get) => ({
             scaleY: element.scale_y,
           })),
           pageCharacters: page.page_characters || [],
+          elementsToDelete: [],
         }));
         set({ pages: formattedPages, bookData: response.data });
       } else {
@@ -268,6 +287,16 @@ const useCanvasStore = create((set, get) => ({
       console.error("ブックデータの取得に失敗しました:", error);
       set({ pages: [] });
     }
+  },
+
+  // 更新後に削除リストをクリアするアクション
+  clearElementsToDelete: () => {
+    set((state) => ({
+      pages: state.pages.map((page) => ({
+        ...page,
+        elementsToDelete: [],
+      })),
+    }));
   },
 
   // モーダル関連


### PR DESCRIPTION
Closes #198

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
ページの更新時に、削除対象の要素（画像やテキスト）が正しく削除されず、データベースに残り続ける問題が発生しています。この問題を解決するための対応を行いました。

## やったこと
<!-- このプルリクで何をしたのか？ -->
- [x]  フロントエンドのelementsToDelete管理の確認
- [x]  handleModalSave関数の修正
- [x] _destroy パラメータの追加
- [x]  バックエンドのPagesController#updateアクションの確認
