### PR TITLE
【バック・フロント】ページネーション

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -60,3 +60,5 @@ gem 'devise-i18n'
 gem 'jsonapi-serializer'
 
 gem 'dotenv-rails', groups: [:development, :test]
+
+gem 'kaminari'

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -133,6 +133,18 @@ GEM
       activesupport (>= 4.2)
     jwt (2.9.3)
       base64
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     logger (1.6.1)
     loofah (2.23.1)
       crass (~> 1.0.2)
@@ -257,6 +269,7 @@ DEPENDENCIES
   dockerfile-rails (>= 1.6)
   dotenv-rails
   jsonapi-serializer
+  kaminari
   pg (~> 1.1)
   puma (>= 5.0)
   rack-cors

--- a/back/app/controllers/api/v1/books_controller.rb
+++ b/back/app/controllers/api/v1/books_controller.rb
@@ -12,28 +12,61 @@ class Api::V1::BooksController < ApplicationController
 
   def public_books
     books = Book.published
-    render json: books, include: [:tags, :pages]
+                .order(created_at: :desc)
+                .page(params[:page])
+                .per(params[:per_page] || 10)
+    render json: {
+      books: books.as_json(
+        include: [:tags, :pages]
+      ),
+      pagination: {
+        current_page: books.current_page,
+        next_page: books.next_page,
+        prev_page: books.prev_page,
+        total_pages: books.total_pages,
+        total_count: books.total_count,
+        limit_value: books.limit_value
+      }
+    }, status: :ok
   end
 
   def my_books
     books = Book.my_books(current_user.id)
-
-    render json: books.as_json(
-      only: [:id, :title, :author_name, :created_at, :user_id, :is_draft, :visibility],
-      include: {
-        pages: { only: [:page_number] },
-        tags: { only: [:name] }
+                .order(created_at: :desc)
+                .page(params[:page])
+                .per(params[:per_page] || 10)
+    render json: {
+      books: books.as_json(
+        only: [:id, :title, :author_name, :created_at, :user_id, :is_draft, :visibility],
+        include: {
+          pages: { only: [:page_number] },
+          tags: { only: [:name] }
+        }
+      ),
+      meta: {
+        current_page: books.current_page,
+        next_page: books.next_page,
+        prev_page: books.prev_page,
+        total_pages: books.total_pages,
+        total_count: books.total_count
       }
-    ), status: :ok
+    }, status: :ok
   end
 
   def index
-    books = Book.published
+    books = Book.published.page(params[:page]).per(params[:per_page] || 10)
     render json: books.as_json(
       only: [:id, :title, :author_name, :created_at],
       include: {
         pages: { only: [:page_number] },
         tags: { only: [:name] }
+      },
+      meta: {
+        current_page: books.current_page,
+        next_page: books.next_page,
+        prev_page: books.prev_page,
+        total_pages: books.total_pages,
+        total_count: books.total_count
       }
     ), status: :ok
   end

--- a/back/app/models/book.rb
+++ b/back/app/models/book.rb
@@ -14,4 +14,7 @@ class Book < ApplicationRecord
   scope :published, -> { where(is_draft: false, visibility: 0) }
   scope :drafts, -> { where(is_draft: true) }
   scope :my_books, ->(user_id) { where(user_id: user_id) }
+
+  # デフォルトの1ページあたりの件数を設定（オプション）
+  paginates_per 10
 end

--- a/front/src/app/components/BookList.jsx
+++ b/front/src/app/components/BookList.jsx
@@ -1,4 +1,3 @@
-// src/components/BookList.jsx
 "use client";
 
 import React from "react";

--- a/front/src/app/components/Pagination.jsx
+++ b/front/src/app/components/Pagination.jsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Pagination = ({ pagination, onPageChange }) => {
+  const { current_page, next_page, prev_page, total_pages } = pagination;
+
+  const createPageNumbers = () => {
+    const pages = [];
+    const maxVisible = 5; // 表示するページ数の最大値
+    let start = Math.max(current_page - Math.floor(maxVisible / 2), 1);
+    let end = start + maxVisible - 1;
+
+    if (end > total_pages) {
+      end = total_pages;
+      start = Math.max(end - maxVisible + 1, 1);
+    }
+
+    for (let i = start; i <= end; i++) {
+      pages.push(i);
+    }
+
+    return pages;
+  };
+
+  const pages = createPageNumbers();
+
+  return (
+    <div className="join">
+      {/* 前ページボタン */}
+      <button
+        className={`join-item btn ${prev_page ? '' : 'btn-disabled'}`}
+        onClick={() => onPageChange(prev_page)}
+        disabled={!prev_page}
+      >
+        Prev
+      </button>
+
+      {/* 最初のページへのリンク */}
+      {current_page > 3 && (
+        <>
+          <button className="join-item btn" onClick={() => onPageChange(1)}>
+            1
+          </button>
+          {current_page > 4 && <button className="join-item btn btn-disabled">...</button>}
+        </>
+      )}
+
+      {/* ページ番号ボタン */}
+      {pages.map((page) => (
+        <button
+          key={page}
+          className={`join-item btn ${page === current_page ? 'btn-active' : ''}`}
+          onClick={() => onPageChange(page)}
+        >
+          {page}
+        </button>
+      ))}
+
+      {/* 最後のページへのリンク */}
+      {current_page < total_pages - 2 && (
+        <>
+          {current_page < total_pages - 3 && <button className="join-item btn btn-disabled">...</button>}
+          <button className="join-item btn" onClick={() => onPageChange(total_pages)}>
+            {total_pages}
+          </button>
+        </>
+      )}
+
+      {/* 次ページボタン */}
+      <button
+        className={`join-item btn ${next_page ? '' : 'btn-disabled'}`}
+        onClick={() => onPageChange(next_page)}
+        disabled={!next_page}
+      >
+        Next
+      </button>
+    </div>
+  );
+};
+
+Pagination.propTypes = {
+  pagination: PropTypes.shape({
+    current_page: PropTypes.number.isRequired,
+    next_page: PropTypes.number,
+    prev_page: PropTypes.number,
+    total_pages: PropTypes.number.isRequired,
+    total_count: PropTypes.number.isRequired,
+    limit_value: PropTypes.number.isRequired,
+  }).isRequired,
+  onPageChange: PropTypes.func.isRequired,
+};
+
+export default Pagination;

--- a/front/src/app/index-books/BookListPage.jsx
+++ b/front/src/app/index-books/BookListPage.jsx
@@ -1,0 +1,74 @@
+'use client';
+
+import React, { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import useBooksStore from "@/stores/booksStore";
+import BookList from "../components/BookList";
+import Pagination from "../components/Pagination";
+
+function BookListPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const pageParam = searchParams.get("page");
+
+  const initialPage = parseInt(pageParam, 10) || 1;
+  const [currentPage, setCurrentPage] = useState(initialPage);
+  const perPage = 10;
+
+  const publishedBooks = useBooksStore((state) => state.publishedBooks);
+  const pagination = useBooksStore((state) => state.pagination);
+  const loading = useBooksStore((state) => state.loading);
+  const error = useBooksStore((state) => state.error);
+  const fetchPublishedBooks = useBooksStore((state) => state.fetchPublishedBooks);
+
+  useEffect(() => {
+    fetchPublishedBooks(currentPage, perPage);
+  }, [fetchPublishedBooks, currentPage, perPage]);
+
+  // URLのクエリパラメータが変更されたときに currentPage を更新
+  useEffect(() => {
+    if (pageParam) {
+      const newPage = parseInt(pageParam, 10);
+      if (!isNaN(newPage) && newPage !== currentPage) {
+        setCurrentPage(newPage);
+      }
+    }
+  }, [pageParam, currentPage]);
+
+  const handlePageChange = (page) => {
+    if (page) {
+      setCurrentPage(page);
+      router.push(`/index-books?page=${page}`);
+    }
+  };
+
+  if (loading)
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <span className="loading loading-dots loading-lg"></span>
+          <p className="mt-4 text-lg font-semibold">ページを読み込んでいます...</p>
+        </div>
+      </div>
+    );
+
+  if (error)
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <p className="text-red-500 text-lg">絵本の読み込み中にエラーが発生しました。</p>
+      </div>
+    );
+
+  return (
+    <div className="flex flex-col items-center justify-center p-8 space-y-8 pb-32">
+      <h1 className="text-3xl font-bold mb-4">みんなの絵本</h1>
+      <BookList books={publishedBooks} pageType="bookListPage" />
+      {/* Paginationコンポーネント */}
+      <div className="mt-4">
+        <Pagination pagination={pagination} onPageChange={handlePageChange} />
+      </div>
+    </div>
+  );
+}
+
+export default BookListPage;

--- a/front/src/app/index-books/page.jsx
+++ b/front/src/app/index-books/page.jsx
@@ -1,18 +1,38 @@
 "use client";
 
-import React, { useEffect } from "react";
-import useBooksStore from '../../stores/booksStore';
+import React, { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import useBooksStore from "@/stores/booksStore";
 import BookList from "../components/BookList";
+import Pagination from "../components/Pagination";
 
 function BookListPage() {
-  const publishedBooks = useBooksStore(state => state.publishedBooks);
-  const loading = useBooksStore(state => state.loading);
-  const error = useBooksStore(state => state.error);
-  const fetchPublishedBooks = useBooksStore(state => state.fetchPublishedBooks);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const pageParam = searchParams.get("page");
+
+  const initialPage = parseInt(pageParam, 10) || 1;
+
+  // 個別に取得する
+  const publishedBooks = useBooksStore((state) => state.publishedBooks);
+  const pagination = useBooksStore((state) => state.pagination);
+  const loading = useBooksStore((state) => state.loading);
+  const error = useBooksStore((state) => state.error);
+  const fetchPublishedBooks = useBooksStore((state) => state.fetchPublishedBooks);
+
+  const [currentPage, setCurrentPage] = useState(initialPage);
+  const perPage = 10; // 1ページあたりの表示件数
 
   useEffect(() => {
-    fetchPublishedBooks();
-  }, [fetchPublishedBooks]);
+    fetchPublishedBooks(currentPage, perPage);
+  }, [fetchPublishedBooks, currentPage, perPage]);
+
+  const handlePageChange = (page) => {
+    if (page) {
+      setCurrentPage(page);
+      router.push(`/index-books?page=${page}`);
+    }
+  };
 
   if (loading)
     return (
@@ -35,6 +55,11 @@ function BookListPage() {
     <div className="flex flex-col items-center justify-center p-8 space-y-8 pb-32">
       <h1 className="text-3xl font-bold mb-4">みんなの絵本</h1>
       <BookList books={publishedBooks} pageType="bookListPage" />
+
+      {/* Paginationコンポーネント */}
+      <div className="mt-4">
+        <Pagination pagination={pagination} onPageChange={handlePageChange} />
+      </div>
     </div>
   );
 }

--- a/front/src/app/index-books/page.jsx
+++ b/front/src/app/index-books/page.jsx
@@ -1,67 +1,10 @@
-"use client";
+import React, { Suspense } from 'react';
+import BookListPage from './BookListPage';
 
-import React, { useEffect, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
-import useBooksStore from "@/stores/booksStore";
-import BookList from "../components/BookList";
-import Pagination from "../components/Pagination";
-
-function BookListPage() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const pageParam = searchParams.get("page");
-
-  const initialPage = parseInt(pageParam, 10) || 1;
-
-  // 個別に取得する
-  const publishedBooks = useBooksStore((state) => state.publishedBooks);
-  const pagination = useBooksStore((state) => state.pagination);
-  const loading = useBooksStore((state) => state.loading);
-  const error = useBooksStore((state) => state.error);
-  const fetchPublishedBooks = useBooksStore((state) => state.fetchPublishedBooks);
-
-  const [currentPage, setCurrentPage] = useState(initialPage);
-  const perPage = 10; // 1ページあたりの表示件数
-
-  useEffect(() => {
-    fetchPublishedBooks(currentPage, perPage);
-  }, [fetchPublishedBooks, currentPage, perPage]);
-
-  const handlePageChange = (page) => {
-    if (page) {
-      setCurrentPage(page);
-      router.push(`/index-books?page=${page}`);
-    }
-  };
-
-  if (loading)
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="text-center">
-          <span className="loading loading-dots loading-lg"></span>
-          <p className="mt-4 text-lg font-semibold">ページを読み込んでいます...</p>
-        </div>
-      </div>
-    );
-
-  if (error)
-    return (
-      <div className="flex items-center justify-center h-screen">
-        <p className="text-red-500 text-lg">絵本の読み込み中にエラーが発生しました。</p>
-      </div>
-    );
-
+export default function Page() {
   return (
-    <div className="flex flex-col items-center justify-center p-8 space-y-8 pb-32">
-      <h1 className="text-3xl font-bold mb-4">みんなの絵本</h1>
-      <BookList books={publishedBooks} pageType="bookListPage" />
-
-      {/* Paginationコンポーネント */}
-      <div className="mt-4">
-        <Pagination pagination={pagination} onPageChange={handlePageChange} />
-      </div>
-    </div>
+    <Suspense fallback={<div>Loading...</div>}>
+      <BookListPage />
+    </Suspense>
   );
 }
-
-export default BookListPage;

--- a/front/src/app/myPage/MyPage.jsx
+++ b/front/src/app/myPage/MyPage.jsx
@@ -1,0 +1,97 @@
+'use client';
+
+import React, { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import useBooksStore from '../../stores/booksStore';
+import useAuthStore from '../../stores/authStore';
+import BookList from "../components/BookList";
+import Pagination from "../components/Pagination";
+
+function MyPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const pageParam = searchParams.get("page");
+
+  const initialPage = parseInt(pageParam, 10) || 1;
+  const [currentPage, setCurrentPage] = useState(initialPage);
+  const perPage = 10;
+
+  const userName = useAuthStore(state => state.userName);
+  const isLoggedIn = useAuthStore(state => state.isLoggedIn);
+  const setUserName = useAuthStore(state => state.setUserName);
+  const pagination = useBooksStore((state) => state.pagination);
+  const myBooks = useBooksStore(state => state.myBooks);
+  const loading = useBooksStore(state => state.loading);
+  const error = useBooksStore(state => state.error);
+  const fetchMyBooks = useBooksStore(state => state.fetchMyBooks);
+
+  // クライアントサイドで userName を初期化
+  useEffect(() => {
+    const storedUserName = localStorage.getItem('userName');
+    if (storedUserName) {
+      setUserName(storedUserName);
+    }
+  }, [setUserName]);
+
+  // currentPage または isLoggedIn が変更されたときにデータをフェッチ
+  useEffect(() => {
+    if (isLoggedIn) {
+      fetchMyBooks(currentPage, perPage);
+    }
+  }, [fetchMyBooks, isLoggedIn, currentPage, perPage]);
+
+  // URLのクエリパラメータが変更されたときに currentPage を更新
+  useEffect(() => {
+    if (pageParam) {
+      const newPage = parseInt(pageParam, 10);
+      if (!isNaN(newPage) && newPage !== currentPage) {
+        setCurrentPage(newPage);
+      }
+    }
+  }, [pageParam, currentPage]);
+
+  const handlePageChange = (page) => {
+    if (page) {
+      setCurrentPage(page);
+      router.push(`/myPage?page=${page}`);
+    }
+  };
+
+  if (!isLoggedIn) {
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <p className="text-lg">ログインしてください。</p>
+      </div>
+    );
+  }
+
+  if (loading)
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <div className="text-center">
+          <span className="loading loading-dots loading-lg"></span>
+          <p className="mt-4 text-lg font-semibold">ページを読み込んでいます...</p>
+        </div>
+      </div>
+    );
+
+  if (error)
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <p className="text-red-500 text-lg">絵本の読み込み中にエラーが発生しました。</p>
+      </div>
+    );
+
+  return (
+    <div className="flex flex-col items-center justify-center p-8 space-y-8 pb-32">
+      <h1 className="text-3xl font-bold mb-4">{userName}さんの絵本</h1>
+      <BookList books={myBooks} pageType="myPage" />
+      {/* Paginationコンポーネント */}
+      <div className="mt-4">
+        <Pagination pagination={pagination} onPageChange={handlePageChange} />
+      </div>
+    </div>
+  );
+}
+
+export default MyPage;

--- a/front/src/app/myPage/page.jsx
+++ b/front/src/app/myPage/page.jsx
@@ -1,97 +1,10 @@
-'use client';
+import React, { Suspense } from 'react';
+import MyPage from './MyPage';
 
-import React, { useEffect, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
-import useBooksStore from '../../stores/booksStore';
-import useAuthStore from '../../stores/authStore';
-import BookList from "../components/BookList";
-import Pagination from "../components/Pagination";
-
-function MyPage() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const pageParam = searchParams.get("page");
-
-  const initialPage = parseInt(pageParam, 10) || 1;
-  const [currentPage, setCurrentPage] = useState(initialPage); // 追加
-  const perPage = 10; // 1ページあたりの表示件数
-
-  const userName = useAuthStore(state => state.userName);
-  const isLoggedIn = useAuthStore(state => state.isLoggedIn);
-  const setUserName = useAuthStore(state => state.setUserName);
-  const pagination = useBooksStore((state) => state.pagination);
-  const myBooks = useBooksStore(state => state.myBooks);
-  const loading = useBooksStore(state => state.loading);
-  const error = useBooksStore(state => state.error);
-  const fetchMyBooks = useBooksStore(state => state.fetchMyBooks);
-
-  // クライアントサイドで userName を初期化
-  useEffect(() => {
-    const storedUserName = localStorage.getItem('userName');
-    if (storedUserName) {
-      setUserName(storedUserName);
-    }
-  }, [setUserName]);
-
-  // currentPage または isLoggedIn が変更されたときにデータをフェッチ
-  useEffect(() => {
-    if (isLoggedIn) {
-      fetchMyBooks(currentPage, perPage); // 修正
-    }
-  }, [fetchMyBooks, isLoggedIn, currentPage, perPage]); // 修正
-
-  // URLのクエリパラメータが変更されたときに currentPage を更新
-  useEffect(() => {
-    if (pageParam) {
-      const newPage = parseInt(pageParam, 10);
-      if (!isNaN(newPage) && newPage !== currentPage) {
-        setCurrentPage(newPage);
-      }
-    }
-  }, [pageParam, currentPage]); // 追加
-
-  const handlePageChange = (page) => {
-    if (page) {
-      setCurrentPage(page); // 定義されたsetCurrentPageを使用
-      router.push(`/myPage?page=${page}`);
-    }
-  };
-
-  if (!isLoggedIn) {
-    return (
-      <div className="flex items-center justify-center h-screen">
-        <p className="text-lg">ログインしてください。</p>
-      </div>
-    );
-  }
-
-  if (loading)
-    return (
-      <div className="flex items-center justify-center h-screen">
-        <div className="text-center">
-          <span className="loading loading-dots loading-lg"></span>
-          <p className="mt-4 text-lg font-semibold">ページを読み込んでいます...</p>
-        </div>
-      </div>
-    );
-
-  if (error)
-    return (
-      <div className="flex items-center justify-center h-screen">
-        <p className="text-red-500 text-lg">絵本の読み込み中にエラーが発生しました。</p>
-      </div>
-    );
-
+export default function Page() {
   return (
-    <div className="flex flex-col items-center justify-center p-8 space-y-8 pb-32">
-      <h1 className="text-3xl font-bold mb-4">{userName}さんの絵本</h1>
-      <BookList books={myBooks} pageType="myPage" />
-      {/* Paginationコンポーネント */}
-      <div className="mt-4">
-        <Pagination pagination={pagination} onPageChange={handlePageChange} />
-      </div>
-    </div>
+    <Suspense fallback={<div>Loading...</div>}>
+      <MyPage />
+    </Suspense>
   );
 }
-
-export default MyPage;

--- a/front/src/stores/booksStore.jsx
+++ b/front/src/stores/booksStore.jsx
@@ -3,20 +3,34 @@ import axiosInstance from '../api/axios';
 
 const useBooksStore = create((set) => ({
   publishedBooks: [], // 公開済みの絵本
-  myBooks: [],        // ユーザーの全ての絵本（公開済みと下書き）
+  myBooks: [],
+  pagination: {
+    current_page: 1,
+    next_page: null,
+    prev_page: null,
+    total_pages: 1,
+    total_count: 0,
+    limit_value: 10,
+  },
   loading: false,
   error: null,
 
   // 公開済みの絵本をフェッチ
-  fetchPublishedBooks: async () => {
+  fetchPublishedBooks: async (page = 1, perPage = 10) => {
     set({ loading: true, error: null });
     try {
-      const response = await axiosInstance.get('/api/v1/books/public_books'); // 修正後の index エンドポイント
-      if (Array.isArray(response.data)) {
-        const sortedBooks = response.data.sort(
+      const response = await axiosInstance.get('/api/v1/books/public_books', {
+        params: { page, per_page: perPage }, // ページネーションパラメータを送信
+      });
+      if (response.data.books && Array.isArray(response.data.books) && response.data.pagination) {
+        const sortedBooks = response.data.books.sort(
           (a, b) => new Date(b.created_at) - new Date(a.created_at)
         );
-        set({ publishedBooks: sortedBooks, loading: false });
+        set({
+          publishedBooks: sortedBooks,
+          pagination: response.data.pagination,
+          loading: false,
+        });
       } else {
         throw new Error("Invalid data format for publishedBooks");
       }
@@ -27,15 +41,21 @@ const useBooksStore = create((set) => ({
   },
 
   // ユーザーの全ての絵本（公開済みと下書き）をフェッチ
-  fetchMyBooks: async () => {
+  fetchMyBooks: async (page = 1, perPage = 10) => {
     set({ loading: true, error: null });
     try {
-      const response = await axiosInstance.get('/api/v1/books/my_books');
-      if (Array.isArray(response.data)) {
-        const sortedBooks = response.data.sort(
+      const response = await axiosInstance.get('/api/v1/books/my_books', {
+        params: { page, per_page: perPage },
+      });
+      if (response.data.books && Array.isArray(response.data.books) && response.data.meta) {
+        const sortedBooks = response.data.books.sort(
           (a, b) => new Date(b.created_at) - new Date(a.created_at)
         );
-        set({ myBooks: sortedBooks, loading: false });
+        set({
+          myBooks: sortedBooks,
+          pagination: response.data.meta, // 'meta' キーを使用
+          loading: false,
+        });
       } else {
         throw new Error("Invalid data format for myBooks");
       }


### PR DESCRIPTION
Closes #158

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
絵本一覧ページにページネーション機能を追加し、ユーザーが効率的に絵本を閲覧できるようにしました。

## やったこと
<!-- このプルリクで何をしたのか？ -->
バックエンド:
- [x] GemfileとGemfile.lockを更新し、ページネーションライブラリ（例: Kaminari）を追加。
- [x] Bookモデルにpaginates_perを設定して、1ページあたりの表示件数を10件に固定。
- [x] BooksControllerのpublic_books、my_books、indexアクションにページネーションロジックを追加し、paginationキーを含むレスポンス形式に統一。

フロントエンド:
- [x] 新規にPagination.jsxコンポーネントを作成し、ページネーションUIを実装。
- [x] BookList.jsxを修正して、ページネーションコンポーネントを統合。
- [x] index-books/page.jsxおよびmyPage/page.jsxを修正し、ページネーションパラメータの取得と状態管理を追加。
- [x] Zustandストア (booksStore.jsx) を更新し、ページネーションデータの取得と管理を実装。

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- なし

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- なし