### PR TITLE
 【バック・フロント】コメントの削除と編集

### DIFF
--- a/back/app/controllers/api/v1/comments_controller.rb
+++ b/back/app/controllers/api/v1/comments_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::CommentsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_book, only: [:index, :create]
-  before_action :set_comment, only: [:destroy]
+  before_action :set_comment, only: [:destroy, :update]
 
   def index
     @comments = @book.comments.includes(:user).order(created_at: :desc)
@@ -16,6 +16,18 @@ class Api::V1::CommentsController < ApplicationController
       render json: @comment.as_json(include: { user: { only: [:id, :name] } }), status: :created
     else
       render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @comment.user == current_user
+      if @comment.update(comment_params)
+        render json: @comment.as_json(include: { user: { only: [:id, :name] } })
+      else
+        render json: { errors: @comment.errors.full_messages }, status: :unprocessable_entity
+      end
+    else
+      render json: { error: "You are not authorized to update this comment." }, status: :forbidden
     end
   end
 

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
       end
       resources :books  do
         resources :pages, only: [:index, :show, :create, :update, :destroy]
-        resources :comments, only: [:index, :create, :destroy]
+        resources :comments, only: [:index, :create, :update, :destroy]
         collection do
           get :public_books
           get :my_books


### PR DESCRIPTION
Closes #205

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
コメントの編集および削除機能を実装し、ユーザーが投稿したコメントを後から修正または削除できるようにする。

## やったこと
<!-- このプルリクで何をしたのか？ -->
- [x]   バックエンド：CommentsController にコメント編集（update アクション）機能を追加
- [x] コメント投稿者のみが編集可能であることを確認
- [x] 編集後のコメントをJSON形式で返す
- [x] エラーハンドリングの実装
- [x] バックエンド：CommentsController にコメント削除（destroy アクション）機能を実装済みであることを確認
- [x] フロントエンド：コメント一覧に「編集」ボタンを追加
- [x] 編集中のUI（textareaと保存/キャンセルボタン）を実装
- [x] 保存ボタンで編集APIを呼び出し、リストを更新
- [x] キャンセルボタンで編集状態を解除
- [x] フロントエンド：コメント一覧に「削除」ボタンを追加済みであることを確認
- [x] 削除ボタンで削除APIを呼び出し、リストを更新

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- なし

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- なし