### PR TITLE
【バック・フロント】下書き機能

### DIFF
--- a/back/app/models/book.rb
+++ b/back/app/models/book.rb
@@ -7,15 +7,18 @@ class Book < ApplicationRecord
 
   accepts_nested_attributes_for :pages, allow_destroy: true
 
-  validates :title, presence: true
-  validates :author_name, presence: true
-  validates :visibility, inclusion: { in: [0, 1] } #0 = 全体公開, 1 = 自分のみ
+  # 下書きではない場合のみ、タイトルと作者名を必須にする
+  validates :title, presence: true, unless: :is_draft
+  validates :author_name, presence: true, unless: :is_draft
+
+  # visibility と is_draft のバリデーション
+  validates :visibility, inclusion: { in: [0, 1] } # 0 = 全体公開, 1 = 自分のみ
   validates :is_draft, inclusion: { in: [true, false] }
 
+  # スコープ
   scope :published, -> { where(is_draft: false, visibility: 0) }
   scope :drafts, -> { where(is_draft: true) }
   scope :my_books, ->(user_id) { where(user_id: user_id) }
 
-  # デフォルトの1ページあたりの件数を設定（オプション）
-  paginates_per 10
+  paginates_per 9
 end

--- a/front/src/app/components/Modal.jsx
+++ b/front/src/app/components/Modal.jsx
@@ -8,7 +8,7 @@ export default function Modal({ isOpen, onClose, onSave, modalType, title, setTi
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center">
       <div className="bg-white p-6 rounded-lg w-80">
-        <h2 className="text-lg font-bold mb-4">{modalType === "draft" ? "下書き保存" : "完成保存"}</h2>
+        <h2 className="text-lg font-bold mb-4">{modalType === "draft" ? "下書き保存（空白でもOKです）" : "完成保存"}</h2>
         <label className="block mb-2">タイトル</label>
         <input type="text" value={title} onChange={(e) => setTitle(e.target.value)} className="w-full p-2 border rounded mb-4" />
         <label className="block mb-2">作者</label>

--- a/front/src/stores/booksStore.jsx
+++ b/front/src/stores/booksStore.jsx
@@ -14,6 +14,7 @@ const useBooksStore = create((set) => ({
   },
   loading: false,
   error: null,
+  setPublishedBooks: (books) => set({ publishedBooks: books }),
 
   // 公開済みの絵本をフェッチ
   fetchPublishedBooks: async (page = 1, perPage = 10) => {


### PR DESCRIPTION
Closes #214

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
下書き機能はタイトルや作者名がなくても保存できるようにし、さらにコントロールSで保存できるようにすることで、下書き保存のハードルを下げる。

## やったこと
<!-- このプルリクで何をしたのか？ -->
- [x] タイトルと作者名のバリデーションを下書き保存時にスキップするよう修正。
- [x] コントロールSまたはコマンドSで下書き保存できるキーボードショートカットを追加。
- [x] 保存後にリロードせず、APIから最新データを取得して状態を更新するロジックを追加。
- [x] 状態の即時反映に対応するためのUIとエラーハンドリングを実装。

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- なし

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- なし