### PR TITLE
【フロント】パスワードを忘れた場合のページガワ作成

### DIFF
--- a/back/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/back/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,6 +1,5 @@
 <p>以下のリンクからパスワードをリセットしてください:</p>
 <p>
-  <a href="http://localhost:3000/reset-password?token=<%= @token %>&email=<%= @resource.email %>">
-    パスワードリセット
+  <a href="<%= ENV['FRONTEND_URL'] %>/reset-password?token=<%= @token %>&email=<%= @resource.email %>">    パスワードリセット
   </a>
 </p>

--- a/front/src/app/forgot-password/page.jsx
+++ b/front/src/app/forgot-password/page.jsx
@@ -1,7 +1,61 @@
-export default function LoginPage() {
+"use client";
+import { useState } from "react";
+import axiosInstance from '../../api/axios';
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setMessage("");
+
+    try {
+      const response = await axiosInstance.post(`/api/v1/auth/password`, {
+        user: { email },
+      });
+
+      if (response.status === 200) {
+        setMessage("パスワード再設定用のメールを送信しました。メールを確認してください。");
+        setEmail("");
+      }
+    } catch (error) {
+      console.error("エラーが発生しました:", error);
+        // サーバーエラーがあれば表示
+        if (error.response && error.response.data && error.response.data.error) {
+          setMessage("エラー: " + error.response.data.error);
+        } else {
+          setMessage("リクエストに失敗しました。もう一度お試しください。");
+        }
+      }
+    };
+
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-100">
-      <h1 className="text-2xl font-bold text-gray-700">パスワードリセットページ。これから</h1>
+    <div className="min-h-screen flex flex-col items-center justify-center">
+      <form onSubmit={handleSubmit} className="max-w-md w-full bg-customBackground p-6 rounded-lg shadow-md">
+        <div className="flex justify-center">
+        <h1 className="text-2xl text-heading font-bold mb-4">パスワードリセット申請</h1>
+        </div>
+        <div className="mb-4">
+          <label className="block text-bodyText mb-2">メールアドレス</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full p-2 border border-gray-300 rounded"
+            required
+          />
+        </div>
+        <div className="flex justify-center">
+          <button
+            type="submit"
+            className="bg-customButton text-white px-4 py-2 rounded-md hover:bg-opacity-80"
+          >
+            送信
+          </button>
+        </div>
+        {message && <p className="mt-4 text-sm text-gray-700">{message}</p>}
+      </form>
     </div>
   );
 }

--- a/front/src/app/reset-password/page.jsx
+++ b/front/src/app/reset-password/page.jsx
@@ -16,21 +16,15 @@ export default function ResetPasswordPage({ searchParams }) {
     setMessage("");
 
     try {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/users/password`, {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
+      const response = await axiosInstance.put(`/api/v1/auth/password`, {
+        user: {
+          reset_password_token: token,
+          password: password,
+          password_confirmation: passwordConfirmation,
         },
-        body: JSON.stringify({
-          user: {
-            reset_password_token: token,
-            password: password,
-            password_confirmation: passwordConfirmation,
-          },
-        }),
       });
 
-      if (response.ok) {
+      if (response.status === 200) {
         alert("パスワードがリセットされました。ログインしてください。");
         router.push("/login");
       } else {
@@ -44,11 +38,13 @@ export default function ResetPasswordPage({ searchParams }) {
   };
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-100">
-      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow-md">
-        <h1 className="text-2xl font-bold mb-4">新しいパスワードの設定</h1>
+    <div className="min-h-screen flex flex-col items-center justify-center">
+      <form onSubmit={handleSubmit} className="max-w-md w-full bg-customBackground p-6 rounded-lg shadow-md">
+        <div className="flex justify-center">
+          <h1 className="text-2xl text-heading font-bold mb-4">新しいパスワードの設定</h1>
+        </div>
         <div className="mb-4">
-          <label className="block text-sm font-bold mb-2">新しいパスワード</label>
+          <label className="block text-bodyText mb-2">新しいパスワード</label>
           <input
             type="password"
             value={password}
@@ -58,7 +54,7 @@ export default function ResetPasswordPage({ searchParams }) {
           />
         </div>
         <div className="mb-4">
-          <label className="block text-sm font-bold mb-2">パスワード確認</label>
+          <label className="block text-bodyText mb-2">パスワード確認</label>
           <input
             type="password"
             value={passwordConfirmation}
@@ -67,12 +63,14 @@ export default function ResetPasswordPage({ searchParams }) {
             required
           />
         </div>
-        <button
-          type="submit"
-          className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
-        >
-          パスワードをリセット
-        </button>
+        <div className="flex justify-center">
+          <button
+            type="submit"
+            className="bg-customButton text-white px-4 py-2 rounded-md hover:bg-opacity-80"
+          >
+            パスワードを再設定
+          </button>
+        </div>
         {message && <p className="mt-4 text-sm text-red-500">{message}</p>}
       </form>
     </div>

--- a/front/src/app/reset-password/page.jsx
+++ b/front/src/app/reset-password/page.jsx
@@ -1,0 +1,80 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function ResetPasswordPage({ searchParams }) {
+  const [password, setPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [message, setMessage] = useState("");
+  const router = useRouter();
+
+  const token = searchParams.token;
+  const email = searchParams.email;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setMessage("");
+
+    try {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/users/password`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          user: {
+            reset_password_token: token,
+            password: password,
+            password_confirmation: passwordConfirmation,
+          },
+        }),
+      });
+
+      if (response.ok) {
+        alert("パスワードがリセットされました。ログインしてください。");
+        router.push("/login");
+      } else {
+        const errorData = await response.json();
+        setMessage("エラー: " + errorData.error);
+      }
+    } catch (error) {
+      console.error("エラーが発生しました:", error);
+      setMessage("リクエストに失敗しました。");
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow-md">
+        <h1 className="text-2xl font-bold mb-4">新しいパスワードの設定</h1>
+        <div className="mb-4">
+          <label className="block text-sm font-bold mb-2">新しいパスワード</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full p-2 border border-gray-300 rounded"
+            required
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block text-sm font-bold mb-2">パスワード確認</label>
+          <input
+            type="password"
+            value={passwordConfirmation}
+            onChange={(e) => setPasswordConfirmation(e.target.value)}
+            className="w-full p-2 border border-gray-300 rounded"
+            required
+          />
+        </div>
+        <button
+          type="submit"
+          className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+        >
+          パスワードをリセット
+        </button>
+        {message && <p className="mt-4 text-sm text-red-500">{message}</p>}
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #21

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
ユーザーがパスワードを忘れた際にパスワードリセット用のメールを受け取れるよう、パスワード再設定リクエスト画面を作成します。

## やったこと
<!-- このプルリクで何をしたのか？ -->
### ユーザーがメールアドレスを入力する画面の作成
- [x] 「パスワードを再設定する」の文言が表示される
- [x] 「メールアドレス」の入力フォームが表示される
- [x]  「送信」ボタンが表示される
- [x]  送信後に「メールアドレス宛にパスワード再設定用のメールを送信しました」が表示される
- [x] 送信後に、フォームが初期化される
- [x] メールアドレスが無効な場合にエラーメッセージを表示
- [x] フロントでメールアドレスを入力し、送信すると、http://localhost:3000/letter_openerにメールが届いていることを確認
### パスワードリセットフォーム画面
- [ ] 
 
## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- 本番環境での設定

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- 

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- なし