### PR TITLE
パスワードリセットの本番環境の設定

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -45,7 +45,6 @@ group :development do
   # gem "spring"
 end
 
-
 gem "dockerfile-rails", ">= 1.6", :group => :development
 
 # 認証機能の基盤
@@ -60,8 +59,7 @@ gem 'devise-i18n'
 # JSON API形式のレスポンス生成
 gem 'jsonapi-serializer'
 
-gem 'dotenv-rails', groups: [:development, :test]
-
+gem 'dotenv-rails'
 gem 'kaminari'
 
 gem 'rmagick'

--- a/back/config/environments/production.rb
+++ b/back/config/environments/production.rb
@@ -65,7 +65,19 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "app_production"
 
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = { host: 'https://make-picture-book.vercel.app' }
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+  address: "smtp.gmail.com",
+  port: 587,
+  domain: "gmail.com",
+  user_name: ENV['GMAIL_USERNAME'],
+  password: ENV['GMAIL_PASSWORD'],
+  authentication: "plain",
+  enable_starttls_auto: true
+  }
+  config.action_mailer.default_url_options = { host: 'https://ehon-ga-pon.com' }
+
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
Closes #22

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
パスワードリセットが本番環境でも動作するように設定。

## やったこと
<!-- このプルリクで何をしたのか？ -->
- [x] Googleのアカウントを追加、アプリパスワードを取得 (https://www.sociac.jp/lacne/news/upload/gmail-pass-setting.pdf を参照)
- [x] 環境変数を設定し、flyにも設定
- [x] back/config/environments/production.rbを設定
