### PR TITLE
【バック】OmniAuthとGoogle OAuth

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -65,3 +65,6 @@ gem 'kaminari'
 gem 'rmagick'
 gem 'meta-tags'
 gem 'launchy'
+
+gem 'omniauth'
+gem 'omniauth-google-oauth2'

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -125,14 +125,22 @@ GEM
       logger
       zeitwerk (~> 2.6)
     erubi (1.13.0)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashie (5.0.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
     irb (1.14.1)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    json (2.9.1)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
     jwt (2.9.3)
@@ -174,7 +182,11 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.2)
     msgpack (1.7.5)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
     mutex_m (0.3.0)
+    net-http (0.6.0)
+      uri
     net-imap (0.5.1)
       date
       net-protocol
@@ -197,7 +209,26 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
+    oauth2 (2.0.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
     observer (0.1.2)
+    omniauth (2.1.2)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-google-oauth2 (1.2.0)
+      jwt (>= 2.9)
+      oauth2 (~> 2.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
+    omniauth-oauth2 (1.8.0)
+      oauth2 (>= 1.4, < 3)
+      omniauth (~> 2.0)
     orm_adapter (0.5.0)
     pg (1.5.9)
     pkg-config (1.5.8)
@@ -210,6 +241,10 @@ GEM
     rack (3.1.8)
     rack-cors (2.0.2)
       rack (>= 2.0.0)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)
@@ -258,11 +293,16 @@ GEM
       observer (~> 0.1)
       pkg-config (~> 1.4)
     securerandom (0.3.2)
+    snaky_hash (2.0.1)
+      hashie
+      version_gem (~> 1.1, >= 1.1.1)
     stringio (3.1.2)
     thor (1.3.2)
     timeout (0.4.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uri (1.0.2)
+    version_gem (1.1.4)
     warden (1.2.9)
       rack (>= 2.0.9)
     warden-jwt_auth (0.10.0)
@@ -296,6 +336,8 @@ DEPENDENCIES
   launchy
   letter_opener_web
   meta-tags
+  omniauth
+  omniauth-google-oauth2
   pg (~> 1.1)
   puma (>= 5.0)
   rack-cors

--- a/back/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
+++ b/back/app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
@@ -1,0 +1,28 @@
+# app/controllers/api/v1/auth/omniauth_callbacks_controller.rb
+
+module Api
+  module V1
+    module Auth
+      class OmniauthCallbacksController < Devise::OmniauthCallbacksController
+        def google_oauth2
+          Rails.logger.debug "OmniauthCallbacksController#google_oauth2 called"
+          Rails.logger.debug "Auth hash: #{request.env['omniauth.auth'].inspect}"
+
+          @user = User.from_omniauth(request.env['omniauth.auth'])
+
+          if @user.persisted?
+            token = @user.generate_jwt # devise-jwtを使用してトークンを生成
+            render json: { token: token, user: @user }, status: :ok
+          else
+            render json: { error: '認証に失敗しました。' }, status: :unauthorized
+          end
+        end
+
+        def failure
+          Rails.logger.debug "OmniauthCallbacksController#failure called"
+          render json: { error: '認証に失敗しました。' }, status: :unauthorized
+        end
+      end
+    end
+  end
+end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable,
+         :omniauthable, omniauth_providers: [:google_oauth2]
 
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
@@ -12,6 +13,22 @@ class User < ApplicationRecord
 
   def jwt_subject
     id
+  end
+
+  # from_omniauthメソッドが正しく定義されていることを確認
+  def self.from_omniauth(auth)
+    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+      user.email = auth.info.email
+      user.password = Devise.friendly_token[0, 20]
+      user.name = auth.info.name
+    end
+  end
+
+
+  # JWTトークン生成メソッドが正しく定義されていることを確認
+  def generate_jwt
+    # JWT生成ロジック（例）
+    JWT.encode({ user_id: id, exp: 24.hours.from_now.to_i }, Rails.application.credentials.dig(:jwt, :secret), 'HS256')
   end
 
   private

--- a/back/config/application.rb
+++ b/back/config/application.rb
@@ -15,6 +15,8 @@ module App
     config.active_record.default_timezone = :local
     config.i18n.default_locale = :ja
     config.i18n.available_locales = [:en, :ja]
-    require 'devise'
+    config.session_store :cookie_store, key: '_ehon_ga_pon_session'
+    config.middleware.insert_before 0, ActionDispatch::Cookies
+    config.middleware.insert_before 1, ActionDispatch::Session::CookieStore, key: '_ehon_ga_pon_session'
   end
 end

--- a/back/config/initializers/devise.rb
+++ b/back/config/initializers/devise.rb
@@ -30,4 +30,18 @@ Devise.setup do |config|
     jwt.expiration_time = 1.day.to_i
     #jwt.revocation_strategy = JwtDenylist
   end
+
+  # 非HTMLリクエストを弾いてしまうので、以下のように緩める
+  config.navigational_formats = ['*/*', :html]
+
+  # OmniAuthのパスプレフィックスを設定
+  config.omniauth_path_prefix = '/api/v1/auth'
+
+  # OmniAuthの設定
+  config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], {
+    scope: 'userinfo.email, userinfo.profile',
+    prompt: 'select_account',
+    redirect_uri: 'http://localhost:3000/api/v1/auth/google_oauth2/callback',
+    redirect_uri: 'https://ehon-ga-pon.com//api/v1/auth/google_oauth2/callback'
+  }
 end

--- a/back/config/initializers/omniauth.rb
+++ b/back/config/initializers/omniauth.rb
@@ -1,0 +1,2 @@
+OmniAuth.config.allowed_request_methods = [:post, :get]
+OmniAuth.config.silence_get_warning = true

--- a/back/config/initializers/session_store.rb
+++ b/back/config/initializers/session_store.rb
@@ -1,0 +1,5 @@
+if Rails.env.production?
+  Rails.application.config.session_store :cookie_store, key: '_ehon_ga_pon_session', domain: '.ehon-ga-pon.com'
+else
+  Rails.application.config.session_store :cookie_store, key: '_ehon_ga_pon_session'
+end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -5,7 +5,8 @@ Rails.application.routes.draw do
   devise_for :users, path: 'api/v1/auth', controllers: {
     sessions: 'api/v1/auth/sessions',
     registrations: 'api/v1/auth/registrations',
-    passwords: 'api/v1/auth/passwords'
+    passwords: 'api/v1/auth/passwords',
+    omniauth_callbacks: 'api/v1/auth/omniauth_callbacks'
   }
 
   namespace :api do

--- a/back/test/controllers/api/v1/auth/omniauth_callbacks_controller_test.rb
+++ b/back/test/controllers/api/v1/auth/omniauth_callbacks_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Api::V1::Auth::OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Closes #147, #148

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- Google OAuth2.0を使用した認証機能を実装

## やったこと
<!-- このプルリクで何をしたのか？ -->
- Google Cloud ConsoleでOAuth2.0クライアントIDを登録
- バックエンドに`omniauth-google-oauth2`Gemを追加
- OmniAuthの設定を`config/initializers/devise.rb`に追加
- ユーザーモデルの変更
- OmniAuth Callbacksコントローラの追加
- Routesの設定変更
- Cookieのセッションストアの設定

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- UIの変更


## できるようになること（ユーザ目端）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- JWTトークンを取得

## できなくなること（ユーザ目端）
<!-- 何ができなくなるのか（あれば。無いなら「無し」でOK） -->
- 無し

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記述） -->
1. Google側の設定を行う
2. Gemgileに以下のGemを追加

```jsx
gem 'omniauth'
gem 'omniauth-google-oauth2'
```

1. back/config/initializers/devise.rbに追記

```jsx
  # OmniAuthの設定
  config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], {
    scope: 'userinfo.email, userinfo.profile',
    prompt: 'select_account',
  }
  
  # OmniAuthのパスプレフィックスを設定
  config.omniauth_path_prefix = '/api/v1/auth'
```

`ENV['GOOGLE_CLIENT_ID']` と `ENV['GOOGLE_CLIENT_SECRET']` は、Google Cloud Consoleで取得したクレデンシャルを設定。

1. back/app/models/user.rbに追記

```jsx
 :omniauthable, omniauth_providers: [:google_oauth2]
 
   def self.from_omniauth(auth)
    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
      user.email = auth.info.email
      user.password = Devise.friendly_token[0, 20] # ランダムなパスワードを生成
      user.name = auth.info.name # Googleアカウントの名前を使用
    end
  end
```

このメソッドは、Google から送られてきたデータ (`auth`) を基にユーザーを検索または作成するためのもの。

Google OAuth2 認証では、Google アカウントに紐づけられた`provider`（`google_oauth2`）と `uid`（Google のユーザーID）送られてきます。

この2つを基に既存のユーザーを検索するためのメソッド。

1. back/db/migrate/20241106014846_devise_create_users.rbに以下の内容があることを確認

```jsx
      ## OAuth (Google)
      t.string :provider
      t.string :uid
```

1. back/app/controllers/api/v1/auth/omniauth_callbacks_controller.rbを作成

```jsx
class Api::V1::Auth::OmniauthCallbacksController < Devise::OmniauthCallbacksController
  def google_oauth2
    @user = User.from_omniauth(request.env['omniauth.auth'])

    if @user.persisted?
      token = @user.generate_jwt # devise-jwtを使用してトークンを生成
      render json: { token: token, user: @user }, status: :ok
    else
      render json: { error: '認証に失敗しました。' }, status: :unauthorized
    end
  end

  def failure
    render json: { error: '認証に失敗しました。' }, status: :unauthorized
  end
end
```

1. back/config/routes.rbにパスを追記

```jsx
devise_for :users, path: 'api/v1/auth', controllers: {
  omniauth_callbacks: 'api/v1/auth/omniauth_callbacks'
}
```

1. back/config/application.rbに追記

```jsx
class Application < Rails::Application
  config.middleware.use ActionDispatch::Cookies
  config.middleware.use ActionDispatch::Session::CookieStore
end
```

`config/application.rb` に**Cookie によるセッションストア** を使えるようにするため、次のような設定を追記

```jsx
config.middleware.insert_before 0, ActionDispatch::Cookies
config.middleware.insert_before 1, ActionDispatch::Session::CookieStore, key: '_ehon_ga_pon_session'
```

back/config/initializers/session_store.rbを作成

```jsx
if Rails.env.production?
  Rails.application.config.session_store :cookie_store, key: '_ehon_ga_pon_session', domain: '.ehon-ga-pon.com'
else
  Rails.application.config.session_store :cookie_store, key: '_ehon_ga_pon_session'
end
```

```jsx
Not found. Authentication passthru.
```

というエラーになる。

Google Cloud Console 側のアカウント設定が完了していなかったことが原因だった。

## 関連Issue
<!-- このセクションでは、このPRが関連するIssueやタスクをリンクする。下記のように記述。 -->

- 関連Issue: #1

