### PR TITLE
【バック・フロント】作者名、タイトル名による絵本の検索機能

### DIFF
--- a/back/app/controllers/api/v1/books_controller.rb
+++ b/back/app/controllers/api/v1/books_controller.rb
@@ -105,8 +105,16 @@ class Api::V1::BooksController < ApplicationController
   private
 
   def apply_filters(books)
-    books = books.search_by_tags(params[:tags].split(',').map(&:strip)) if params[:tags].present?
-    books = books.search_by_query(params[:query].strip) if params[:query].present?
+    if params[:tags].present?
+      tags = params[:tags].split(',').map(&:strip)
+      books = books.search_by_tags(tags)
+    end
+    if params[:title].present?
+      books = books.search_by_title(params[:title].strip)
+    end
+    if params[:author].present?
+      books = books.search_by_author(params[:author].strip)
+    end
     books
   end
 

--- a/back/app/controllers/api/v1/books_controller.rb
+++ b/back/app/controllers/api/v1/books_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::BooksController < ApplicationController
-  before_action :authenticate_user!, only: [:create,:author_status]
+  before_action :authenticate_user!, except: [:index, :show, :public_books]
 
   def author_status
     book = Book.find(params[:id]) # IDから絵本を取得
@@ -12,13 +12,7 @@ class Api::V1::BooksController < ApplicationController
 
   def public_books
     books = Book.published
-    # タグ検索処理を追加
-    if params[:tags].present?
-      tags = params[:tags].split(',').map(&:strip)
-      books = books.joins(:tags)
-                  .where('tags.name ILIKE ANY (ARRAY[?])', tags.map { |tag| "%#{tag}%" })
-                  .distinct
-    end
+    books = apply_filters(books)
     books = books.order(created_at: :desc)
                 .page(params[:page])
                 .per(params[:per_page] || 9)
@@ -26,20 +20,14 @@ class Api::V1::BooksController < ApplicationController
       books: books.as_json(
         include: [:tags, :pages]
       ),
-      pagination: {
-        current_page: books.current_page,
-        next_page: books.next_page,
-        prev_page: books.prev_page,
-        total_pages: books.total_pages,
-        total_count: books.total_count,
-        limit_value: books.limit_value
-      }
+      pagination: pagination_meta(books)
     }, status: :ok
   end
 
   def my_books
     books = Book.my_books(current_user.id)
                 .order(created_at: :desc)
+    books = apply_filters(books)
                 .page(params[:page])
                 .per(params[:per_page] || 9)
     render json: {
@@ -50,47 +38,24 @@ class Api::V1::BooksController < ApplicationController
           tags: { only: [:name] }
         }
       ),
-      meta: {
-        current_page: books.current_page,
-        next_page: books.next_page,
-        prev_page: books.prev_page,
-        total_pages: books.total_pages,
-        total_count: books.total_count
-      }
+      meta: pagination_meta(books)
     }, status: :ok
   end
 
   def index
     books = Book.published
-    # タグ検索処理
-    if params[:tags].present?
-      tags = params[:tags].split(',').map(&:strip) # カンマ区切りで複数のタグを取得
-      books = books.joins(:tags).where('tags.name ILIKE ANY (ARRAY[?])', tags.map { |tag| "%#{tag}%" }).distinct
-    end
+    books = apply_filters(books)
     books = books.page(params[:page]).per(params[:per_page] || 9)
-    render json: books.as_json(
-      only: [:id, :title, :author_name, :created_at],
-      include: {
-        pages: { only: [:page_number] },
-        tags: { only: [:name] }
-      },
-      meta: {
-        current_page: books.current_page,
-        next_page: books.next_page,
-        prev_page: books.prev_page,
-        total_pages: books.total_pages,
-        total_count: books.total_count
-      }
-    ), status: :ok
-  end
-
-  def create
-    book = current_user.books.build(book_params)
-    if book.save
-      render json: { message: 'Book created successfully', book: book }, status: :created
-    else
-      render json: { errors: book.errors.full_messages }, status: :unprocessable_entity
-    end
+    render json: {
+      books: books.as_json(
+        only: [:id, :title, :author_name, :created_at],
+        include: {
+          pages: { only: [:page_number] },
+          tags: { only: [:name] }
+        }
+      ),
+      meta: pagination_meta(books)
+    }, status: :ok
   end
 
   def show
@@ -135,9 +100,26 @@ class Api::V1::BooksController < ApplicationController
     render json: { message: 'Book deleted successfully' }, status: :ok
     rescue ActiveRecord::RecordNotFound
       render json:{ error: "Book not found or not authorized" }, status: :not_found
-    end
+  end
 
   private
+
+  def apply_filters(books)
+    books = books.search_by_tags(params[:tags].split(',').map(&:strip)) if params[:tags].present?
+    books = books.search_by_query(params[:query].strip) if params[:query].present?
+    books
+  end
+
+  def pagination_meta(books)
+    {
+      current_page: books.current_page,
+      next_page: books.next_page,
+      prev_page: books.prev_page,
+      total_pages: books.total_pages,
+      total_count: books.total_count,
+      limit_value: books.limit_value
+    }
+  end
 
   def book_params
     params.require(:book).permit(:title, :author_name, :visibility, :is_draft, tags: [])

--- a/back/app/models/book.rb
+++ b/back/app/models/book.rb
@@ -22,8 +22,11 @@ class Book < ApplicationRecord
   scope :search_by_tags, ->(tags) {
     joins(:tags).where('tags.name ILIKE ANY (ARRAY[?])', tags.map { |tag| "%#{tag}%" }).distinct
   }
-  scope :search_by_query, ->(query) {
-    where('books.title ILIKE ? OR books.author_name ILIKE ?', "%#{query}%", "%#{query}%")
+  scope :search_by_title, ->(title) {
+    where('books.title ILIKE ?', "%#{title}%") if title.present?
+  }
+  scope :search_by_author, ->(author) {
+    where('books.author_name ILIKE ?', "%#{author}%") if author.present?
   }
 
   paginates_per 9

--- a/back/app/models/book.rb
+++ b/back/app/models/book.rb
@@ -19,6 +19,12 @@ class Book < ApplicationRecord
   scope :published, -> { where(is_draft: false, visibility: 0) }
   scope :drafts, -> { where(is_draft: true) }
   scope :my_books, ->(user_id) { where(user_id: user_id) }
+  scope :search_by_tags, ->(tags) {
+    joins(:tags).where('tags.name ILIKE ANY (ARRAY[?])', tags.map { |tag| "%#{tag}%" }).distinct
+  }
+  scope :search_by_query, ->(query) {
+    where('books.title ILIKE ? OR books.author_name ILIKE ?', "%#{query}%", "%#{query}%")
+  }
 
   paginates_per 9
 

--- a/front/src/app/components/BookList.jsx
+++ b/front/src/app/components/BookList.jsx
@@ -2,13 +2,14 @@
 
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
-import { FaLock, FaLockOpen, FaEdit, FaCheckCircle, FaTrash } from "react-icons/fa";
+import { FaLock, FaLockOpen, FaEdit, FaCheckCircle, FaTrash, FaSearch, FaTimes } from "react-icons/fa";
 import axiosInstance from '../../api/axios';
 
 function BookList({ books, pageType, isAuthor, handleEdit, handleDelete, rowStyles = [] }) {
   const columnsPerRow = 3; // 1行あたりの列数
   const [searchTags, setSearchTags] = useState("");
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchTitle, setSearchTitle] = useState("");
+  const [searchAuthor, setSearchAuthor] = useState("");
   const [filteredBooks, setFilteredBooks] = useState([]);
   const [isSearching, setIsSearching] = useState(false);
 
@@ -18,15 +19,15 @@ function BookList({ books, pageType, isAuthor, handleEdit, handleDelete, rowStyl
     try {
       const tagsQuery = searchTags.split(',').map(tag => tag.trim()).join(',');
       const params = {
-          page: 1,
-          per_page: 9
-        };
-        if (tagsQuery) params.tags = tagsQuery;
-
-        if (searchQuery.trim()) params.query = searchQuery.trim();
-        const response = await axiosInstance.get('/api/v1/books', { params });
-        setFilteredBooks(response.data.books);
-      } catch (error) {
+        page: 1,
+        per_page: 9
+      };
+      if (tagsQuery) params.tags = tagsQuery;
+      if (searchTitle.trim()) { params.title = searchTitle.trim(); }
+      if (searchAuthor.trim()) { params.author = searchAuthor.trim(); }
+      const response = await axiosInstance.get('/api/v1/books', { params });
+      setFilteredBooks(response.data.books);
+    } catch (error) {
       console.error("検索中にエラーが発生しました:", error);
       alert("検索中にエラーが発生しました");
     } finally {
@@ -37,7 +38,8 @@ function BookList({ books, pageType, isAuthor, handleEdit, handleDelete, rowStyl
   // リセット関数
   const handleResetSearch = () => {
     setSearchTags("");
-    setSearchQuery("");
+    setSearchTitle("");
+    setSearchAuthor("");
     setFilteredBooks(books);
   };
 
@@ -49,45 +51,58 @@ function BookList({ books, pageType, isAuthor, handleEdit, handleDelete, rowStyl
   return (
     <div>
       {/* 検索フォーム */}
-      <div className="mb-8 flex flex-col md:flex-row items-center gap-4">
+      <div className="mb-8 flex flex-row items-center gap-2 overflow-x-auto">
         {/* タグ検索 */}
-        <div className="flex items-center flex-grow">
+        <div className="flex items-center flex-shrink-0">
           <input
             type="text"
             value={searchTags}
             onChange={(e) => setSearchTags(e.target.value)}
             placeholder="タグで検索（カンマ区切り）"
-            className="flex-grow p-2 border rounded-l-md"
+            className="flex-grow min-w-[150px] p-2 border rounded-md"
           />
         </div>
-        {/* タイトル・作者名検索 */}
-        <div className="flex items-center flex-grow">
+        {/* タイトル検索 */}
+        <div className="flex items-center flex-shrink-0">
           <input
             type="text"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="タイトルまたは作者名で検索"
-            className="flex-grow p-2 border rounded-md"
+            value={searchTitle}
+            onChange={(e) => setSearchTitle(e.target.value)}
+            placeholder="タイトルで検索"
+            className="flex-grow min-w-[150px] p-2 border rounded-md"
+          />
+        </div>
+        {/* 作者名検索 */}
+        <div className="flex items-center flex-shrink-0">
+          <input
+            type="text"
+            value={searchAuthor}
+            onChange={(e) => setSearchAuthor(e.target.value)}
+            placeholder="作者名で検索"
+            className="flex-grow min-w-[150px] p-2 border rounded-md"
           />
         </div>
         {/* 検索ボタン */}
         <button
-          onClick={() => {
-            handleSearch();
-          }}
-          className="p-2 bg-customButton text-white rounded-r-md hover:bg-opacity-80"
+          onClick={handleSearch}
+          className="p-2 bg-customButton text-white rounded-md hover:bg-opacity-80 flex-shrink-0"
           disabled={isSearching}
+          aria-label={isSearching ? "検索中" : "検索"}
+          title={isSearching ? "検索中" : "検索"}
         >
-          {isSearching ? "検索中..." : "検索"}
+          {isSearching ? "検索中..." : <FaSearch className="w-5 h-5" />}
         </button>
-        {(searchTags || searchQuery) && (
-          <button
-            onClick={handleResetSearch}
-            className="ml-2 p-2 bg-gray-400 text-white rounded-md hover:bg-gray-500"
-          >
-            リセット
-          </button>
-        )}
+        {/* クリアボタンを常にレンダリングし、表示・非表示を制御 */}
+        <button
+          onClick={handleResetSearch}
+          className={`p-2 bg-gray-400 text-white rounded-md hover:bg-gray-500 flex-shrink-0 ${
+            searchTags || searchTitle || searchAuthor ? "visible" : "invisible"
+          }`}
+          aria-label="クリア"
+          title="クリア"
+        >
+          <FaTimes className="w-5 h-5" />
+        </button>
       </div>
 
       {/* 絞り込みされた書籍の表示 */}
@@ -143,7 +158,7 @@ function BookList({ books, pageType, isAuthor, handleEdit, handleDelete, rowStyl
               <div
                 key={book.id}
                 onClick={() => (window.location.href = `/books/${book.id}`)}
-                className="relative w-[192px] h-[216px] flex flex-col justify-between p-4 bg-customBackground rounded-lg shadow-md cursor-pointer transform transition-transform hover:translate-y-[-64px]"
+                className="relative w-[192px] h-[216px] flex flex-col justify-between p-4 bg-customBackground rounded-lg shadow-md cursor-pointer transform transition-transform hover:translate-y-[-16px] overflow-hidden"
                 style={{ zIndex: rowStyle.zIndex }}
               >
                 {/* 上部左側: ステータスと公開情報 */}
@@ -214,7 +229,7 @@ function BookList({ books, pageType, isAuthor, handleEdit, handleDelete, rowStyl
             );
           })
         ) : (
-          <p className="col-span-3 text-center text-gray-500">該当する絵本がありません。</p>
+          <p className="col-span-1 sm:col-span-2 md:col-span-3 lg:col-span-4 text-center text-gray-500">該当する絵本がありません。</p>
         )}
       </div>
     </div>


### PR DESCRIPTION
Closes #157

## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
本プルリクエストでは、ユーザーがタグ、タイトル、作者名で絵本を検索できる機能を追加しました。また、検索フォームのレイアウトをレスポンシブ対応にし、ユーザーインターフェースの利便性を向上させました。

## やったこと
<!-- このプルリクで何をしたのか？ -->
- タグ、タイトル、作者名による検索機能の実装
- 検索ボタンとクリアボタンに直感的なアイコン（検索アイコンとクリアアイコン）の導入
- 検索フォームのレスポンシブデザインの適用により、画面サイズに関係なく一列に整然と並ぶよう調整
- 検索フォーム内の入力欄の幅を固定し、レイアウトの崩れを防止

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- なし

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- タグ、タイトル、作者名を用いて絵本を効率的に検索できるようになります。
- 検索結果をクリアすることで、元の全絵本リストに簡単に戻ることができます。

## できなくなること（ユーザ目線）
<!-- 何ができなくなるのか？（あれば。無いなら「無し」でOK） -->
- なし

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- 各検索フィールドにタグ、タイトル、作者名を入力し、正しく絞り込みが行われることを確認しました。
- クリアボタンが必要な場合にのみ表示され、クリックすると検索条件がリセットされることを確認しました。
- 検索ボタンとクリアボタンのアイコンが正しく表示され、クリック時に期待通りの動作をすることを確認しました。