### PR TITLE
検索機能修正

### DIFF
--- a/front/src/app/components/BookDetailPage.jsx
+++ b/front/src/app/components/BookDetailPage.jsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useEffect, useState, useRef } from "react";
-import Link from 'next/link';
 import { useParams, useRouter } from "next/navigation";
 import dynamic from "next/dynamic";
 import axiosInstance from '../../api/axios';

--- a/front/src/app/components/BookList.jsx
+++ b/front/src/app/components/BookList.jsx
@@ -10,7 +10,7 @@ function BookList({ books, pageType, isAuthor, handleEdit, handleDelete, rowStyl
   return (
     <div>
       {/* 絞り込みされた書籍の表示 */}
-      <div className="grid gap-4 grid-cols-3 auto-rows-[216px]">
+      <div className="grid gap-4 grid-cols-3 auto-rows-[214px]">
         {Array.isArray(books) && books.length > 0 ? (
           books.map((book, index) => {
             const rowIndex = Math.floor(index / columnsPerRow);
@@ -59,7 +59,7 @@ function BookList({ books, pageType, isAuthor, handleEdit, handleDelete, rowStyl
               <div
                 key={book.id}
                 onClick={() => (window.location.href = `/books/${book.id}`)}
-                className="relative w-[192px] h-[216px] flex flex-col justify-between p-4 bg-customBackground rounded-lg shadow-md cursor-pointer transform transition-transform hover:translate-y-[-16px] overflow-hidden"
+                className="relative w-[192px] h-[216px] flex flex-col justify-between p-4 bg-customBackground rounded-lg shadow-md cursor-pointer transform transition-transform hover:translate-y-[-80px] overflow-hidden"
                 style={{ zIndex: rowStyle.zIndex }}
               >
                 {/* 上部左側: ステータスと公開情報 */}

--- a/front/src/app/components/BookList.jsx
+++ b/front/src/app/components/BookList.jsx
@@ -1,114 +1,18 @@
 'use client';
 
-import React, { useState, useEffect } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import { FaLock, FaLockOpen, FaEdit, FaCheckCircle, FaTrash, FaSearch, FaTimes } from "react-icons/fa";
-import axiosInstance from '../../api/axios';
 
 function BookList({ books, pageType, isAuthor, handleEdit, handleDelete, rowStyles = [] }) {
   const columnsPerRow = 3; // 1行あたりの列数
-  const [searchTags, setSearchTags] = useState("");
-  const [searchTitle, setSearchTitle] = useState("");
-  const [searchAuthor, setSearchAuthor] = useState("");
-  const [filteredBooks, setFilteredBooks] = useState([]);
-  const [isSearching, setIsSearching] = useState(false);
-
-  // 検索関数
-  const handleSearch = async () => {
-    setIsSearching(true);
-    try {
-      const tagsQuery = searchTags.split(',').map(tag => tag.trim()).join(',');
-      const params = {
-        page: 1,
-        per_page: 9
-      };
-      if (tagsQuery) params.tags = tagsQuery;
-      if (searchTitle.trim()) { params.title = searchTitle.trim(); }
-      if (searchAuthor.trim()) { params.author = searchAuthor.trim(); }
-      const response = await axiosInstance.get('/api/v1/books', { params });
-      setFilteredBooks(response.data.books);
-    } catch (error) {
-      console.error("検索中にエラーが発生しました:", error);
-      alert("検索中にエラーが発生しました");
-    } finally {
-      setIsSearching(false);
-    }
-  };
-
-  // リセット関数
-  const handleResetSearch = () => {
-    setSearchTags("");
-    setSearchTitle("");
-    setSearchAuthor("");
-    setFilteredBooks(books);
-  };
-
-  // 初期表示時やbooksの更新時にfilteredBooksを更新
-  useEffect(() => {
-    setFilteredBooks(books);
-  }, [books]);
 
   return (
     <div>
-      {/* 検索フォーム */}
-      <div className="mb-8 flex flex-row items-center gap-2 overflow-x-auto">
-        {/* タグ検索 */}
-        <div className="flex items-center flex-shrink-0">
-          <input
-            type="text"
-            value={searchTags}
-            onChange={(e) => setSearchTags(e.target.value)}
-            placeholder="タグで検索（カンマ区切り）"
-            className="flex-grow min-w-[150px] p-2 border rounded-md"
-          />
-        </div>
-        {/* タイトル検索 */}
-        <div className="flex items-center flex-shrink-0">
-          <input
-            type="text"
-            value={searchTitle}
-            onChange={(e) => setSearchTitle(e.target.value)}
-            placeholder="タイトルで検索"
-            className="flex-grow min-w-[150px] p-2 border rounded-md"
-          />
-        </div>
-        {/* 作者名検索 */}
-        <div className="flex items-center flex-shrink-0">
-          <input
-            type="text"
-            value={searchAuthor}
-            onChange={(e) => setSearchAuthor(e.target.value)}
-            placeholder="作者名で検索"
-            className="flex-grow min-w-[150px] p-2 border rounded-md"
-          />
-        </div>
-        {/* 検索ボタン */}
-        <button
-          onClick={handleSearch}
-          className="p-2 bg-customButton text-white rounded-md hover:bg-opacity-80 flex-shrink-0"
-          disabled={isSearching}
-          aria-label={isSearching ? "検索中" : "検索"}
-          title={isSearching ? "検索中" : "検索"}
-        >
-          {isSearching ? "検索中..." : <FaSearch className="w-5 h-5" />}
-        </button>
-        {/* クリアボタンを常にレンダリングし、表示・非表示を制御 */}
-        <button
-          onClick={handleResetSearch}
-          className={`p-2 bg-gray-400 text-white rounded-md hover:bg-gray-500 flex-shrink-0 ${
-            searchTags || searchTitle || searchAuthor ? "visible" : "invisible"
-          }`}
-          aria-label="クリア"
-          title="クリア"
-        >
-          <FaTimes className="w-5 h-5" />
-        </button>
-      </div>
-
       {/* 絞り込みされた書籍の表示 */}
       <div className="grid gap-4 grid-cols-3 auto-rows-[216px]">
-        {Array.isArray(filteredBooks) && filteredBooks.length > 0 ? (
-          filteredBooks.map((book, index) => {
+        {Array.isArray(books) && books.length > 0 ? (
+          books.map((book, index) => {
             const rowIndex = Math.floor(index / columnsPerRow);
             const rowStyle = rowStyles[rowIndex % rowStyles.length] || {};
             const getVisibilityDetails = (book) => {
@@ -133,7 +37,6 @@ function BookList({ books, pageType, isAuthor, handleEdit, handleDelete, rowStyl
                 };
               }
             };
-
             const getStatusDetails = (book) => {
               if (pageType !== "myPage") {
                 return null;
@@ -150,10 +53,8 @@ function BookList({ books, pageType, isAuthor, handleEdit, handleDelete, rowStyl
                     icon: <FaCheckCircle className="mr-1" aria-label="完成" />,
                   };
             };
-
             const visibility = getVisibilityDetails(book);
             const status = getStatusDetails(book);
-
             return (
               <div
                 key={book.id}
@@ -182,7 +83,6 @@ function BookList({ books, pageType, isAuthor, handleEdit, handleDelete, rowStyl
                     </span>
                   )}
                 </div>
-
                 {/* 上部右側: 編集と削除ボタン */}
                 {isAuthor && (
                   <div className="absolute top-2 right-2 flex gap-2">
@@ -208,7 +108,6 @@ function BookList({ books, pageType, isAuthor, handleEdit, handleDelete, rowStyl
                     </button>
                   </div>
                 )}
-
                 {/* 書籍情報 */}
                 <div className="text-center flex-grow">
                   <h2 className="text-xl font-bold mt-4 overflow-hidden text-ellipsis whitespace-nowrap">
@@ -218,7 +117,6 @@ function BookList({ books, pageType, isAuthor, handleEdit, handleDelete, rowStyl
                 <p className="text-bodyText text-sm mt-auto text-center">
                   作者: {book.author_name}
                 </p>
-
                 {/* ファビコン画像 */}
                 <img
                   src="/home/favicon.png"
@@ -239,14 +137,17 @@ function BookList({ books, pageType, isAuthor, handleEdit, handleDelete, rowStyl
 BookList.propTypes = {
   books: PropTypes.array.isRequired,
   pageType: PropTypes.oneOf(["myPage", "bookListPage"]).isRequired,
-  isAuthor: PropTypes.bool.isRequired, // 作者かどうかの判定
-  handleEdit: PropTypes.func.isRequired, // 編集ボタンのハンドラ
-  handleDelete: PropTypes.func.isRequired, // 削除ボタンのハンドラ
+  isAuthor: PropTypes.bool,
+  handleEdit: PropTypes.func,
+  handleDelete: PropTypes.func,
   rowStyles: PropTypes.array, // 行ごとのスタイルを受け取るプロップ
 };
 
 BookList.defaultProps = {
   rowStyles: [],
+  isAuthor: false,
+  handleEdit: () => {},
+  handleDelete: () => {},
 };
 
 export default BookList;

--- a/front/src/app/components/BookList.jsx
+++ b/front/src/app/components/BookList.jsx
@@ -4,7 +4,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { FaLock, FaLockOpen, FaEdit, FaCheckCircle, FaTrash, FaSearch, FaTimes } from "react-icons/fa";
 
-function BookList({ books, pageType, isAuthor, handleEdit, handleDelete, rowStyles = [] }) {
+function BookList({ books, pageType, isAuthor, handleEdit, handleDelete, rowStyles = [], hoverTranslateYClass = "hover:translate-y-[-80px]" }) {
   const columnsPerRow = 3; // 1行あたりの列数
 
   return (
@@ -59,7 +59,7 @@ function BookList({ books, pageType, isAuthor, handleEdit, handleDelete, rowStyl
               <div
                 key={book.id}
                 onClick={() => (window.location.href = `/books/${book.id}`)}
-                className="relative w-[192px] h-[216px] flex flex-col justify-between p-4 bg-customBackground rounded-lg shadow-md cursor-pointer transform transition-transform hover:translate-y-[-80px] overflow-hidden"
+                className={`relative w-[192px] h-[216px] flex flex-col justify-between p-4 bg-customBackground rounded-lg shadow-md cursor-pointer transform transition-transform overflow-hidden ${hoverTranslateYClass}`}
                 style={{ zIndex: rowStyle.zIndex }}
               >
                 {/* 上部左側: ステータスと公開情報 */}

--- a/front/src/app/index-books/BookListPage.jsx
+++ b/front/src/app/index-books/BookListPage.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import useBooksStore from "@/stores/booksStore";
 import BookList from "../components/BookList";
 import Pagination from "../components/Pagination";
@@ -24,11 +24,10 @@ function BookListPage({ rowStyles = [] }) {
   const resetSearch = useBooksStore((state) => state.resetSearch);
   const filteredBooks = useBooksStore((state) => state.filteredBooks);
   const isSearching = useBooksStore((state) => state.isSearching);
-  const searchParams = useBooksStore((state) => state.searchParams);
 
-  // ページ番号の取得（例として、1ページ目をデフォルトとする）
-  const pageParam = typeof window !== 'undefined' ? new URLSearchParams(window.location.search).get("page") : 1;
-  const tagsParam = typeof window !== 'undefined' ? new URLSearchParams(window.location.search).get("tags") : "";
+  const searchParams = useSearchParams();
+  const pageParam = searchParams.get("page") || "1";
+  const tagsParam = searchParams.get("tags") || "";
 
   // URLの `page` パラメータが変更されたときにデータを取得
   useEffect(() => {
@@ -143,7 +142,7 @@ function BookListPage({ rowStyles = [] }) {
         pageType="bookListPage"
         rowStyles={rowStyles}
       />
-      <div className="mt-4">
+      <div className="mt-4 z-10">
         <Pagination pagination={pagination} onPageChange={handlePageChange} />
       </div>
     </div>

--- a/front/src/app/index-books/BookListPage.jsx
+++ b/front/src/app/index-books/BookListPage.jsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect } from "react";
-import { useRouter, useSearchParams } from "next/navigation"; // ここがポイント
+import { useRouter, useSearchParams } from "next/navigation";
 import useBooksStore from "@/stores/booksStore";
 import BookList from "../components/BookList";
 import Pagination from "../components/Pagination";
@@ -10,7 +10,7 @@ import { FaSearch, FaTimes } from "react-icons/fa";
 
 function BookListPage({ rowStyles = [] }) {
   const router = useRouter();
- const searchParams = useSearchParams(); // 追加
+  const searchParams = useSearchParams();
 
   const perPage = 9;
 
@@ -37,12 +37,14 @@ function BookListPage({ rowStyles = [] }) {
   useEffect(() => {
     const page = parseInt(pageParam, 10) || 1;
     fetchPublishedBooks(page, perPage, tagsParam);
+    if (tagsParam) {
+      setSearchParams({ tags: tagsParam });
+    }
   }, [fetchPublishedBooks, pageParam, perPage, tagsParam]);
 
   // ページ変更時のハンドラー
   const handlePageChange = (page) => {
     if (page) {
-      // タグがあれば &tags=... を付与
       router.push(
         `/index-books?page=${page}${tagsParam ? `&tags=${encodeURIComponent(tagsParam)}` : ""}`
       );
@@ -106,7 +108,7 @@ function BookListPage({ rowStyles = [] }) {
             name="tags"
             value={storeSearchParams.tags}
             onChange={handleInputChange}
-            placeholder="タグで検索（カンマ区切り）"
+            placeholder={tagsParam ? `#${tagsParam}` : "タグで検索（カンマ区切り）"}
             className="flex-grow min-w-[150px] p-2 border rounded-md"
           />
         </div>

--- a/front/src/app/index-books/BookListPage.jsx
+++ b/front/src/app/index-books/BookListPage.jsx
@@ -1,34 +1,38 @@
 'use client';
 
-import React, { useEffect, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import React, { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import useBooksStore from "@/stores/booksStore";
 import BookList from "../components/BookList";
 import Pagination from "../components/Pagination";
 import PropTypes from "prop-types";
-import axiosInstance from '@/api/axios';
-
+import { FaSearch, FaTimes } from "react-icons/fa";
 
 function BookListPage({ rowStyles = [] }) {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const pageParam = searchParams.get("page");
-  const [books, setBooks] = useState([]);
-  const tagsQuery = searchParams.get("tags");
-  const tagsParam = searchParams.get("tags");
 
   const perPage = 9;
 
-  // ストアから必要なデータを取得
+  // ストアから必要なデータとアクションを取得
   const publishedBooks = useBooksStore((state) => state.publishedBooks);
   const pagination = useBooksStore((state) => state.pagination);
   const loading = useBooksStore((state) => state.loading);
   const error = useBooksStore((state) => state.error);
   const fetchPublishedBooks = useBooksStore((state) => state.fetchPublishedBooks);
+  const searchBooks = useBooksStore((state) => state.searchBooks);
+  const setSearchParams = useBooksStore((state) => state.setSearchParams);
+  const resetSearch = useBooksStore((state) => state.resetSearch);
+  const filteredBooks = useBooksStore((state) => state.filteredBooks);
+  const isSearching = useBooksStore((state) => state.isSearching);
+  const searchParams = useBooksStore((state) => state.searchParams);
+
+  // ページ番号の取得（例として、1ページ目をデフォルトとする）
+  const pageParam = typeof window !== 'undefined' ? new URLSearchParams(window.location.search).get("page") : 1;
+  const tagsParam = typeof window !== 'undefined' ? new URLSearchParams(window.location.search).get("tags") : "";
 
   // URLの `page` パラメータが変更されたときにデータを取得
   useEffect(() => {
-    const page = parseInt(pageParam, 9) || 1;
+    const page = parseInt(pageParam, 10) || 1;
     fetchPublishedBooks(page, perPage, tagsParam);
   }, [fetchPublishedBooks, pageParam, perPage, tagsParam]);
 
@@ -39,43 +43,22 @@ function BookListPage({ rowStyles = [] }) {
     }
   };
 
-  useEffect(() => {
-    async function fetchFilteredBooks() {
-      try {
-        const response = await axiosInstance.get("/api/v1/books", {
-          params: {
-            tags: tagsQuery,
-            page: 1,
-            per_page: 9,
-          },
-        });
-        setBooks(response.data);
-      } catch (error) {
-        console.error("書籍の取得に失敗しました:", error);
-      }
-    }
+  const handleSearch = () => {
+    searchBooks();
+    // 必要に応じて URL を更新
+    router.push(`/index-books?page=1${searchParams.tags ? `&tags=${searchParams.tags}` : ""}${searchParams.title ? `&title=${searchParams.title}` : ""}${searchParams.author ? `&author=${searchParams.author}` : ""}`);
+  };
 
-    async function fetchAllBooks() {
-      try {
-        const response = await axiosInstance.get("/api/v1/books", {
-          params: {
-            page: 1,
-            per_page: 9,
-          },
-        });
-        setBooks(response.data);
-      } catch (error) {
-        console.error("書籍の取得に失敗しました:", error);
-      }
-    }
+  const handleResetSearch = () => {
+    resetSearch();
+    // 必要に応じて URL をリセット
+    router.push(`/index-books?page=1`);
+  };
 
-    if (tagsQuery) {
-      fetchFilteredBooks();
-    } else {
-      fetchAllBooks();
-    }
-  }, [tagsQuery]);
-
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setSearchParams({ [name]: value });
+  };
 
   // エラー状態
   if (error)
@@ -85,11 +68,78 @@ function BookListPage({ rowStyles = [] }) {
       </div>
     );
 
+  // ローディング状態
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <p className="text-gray-500 text-lg">読み込み中...</p>
+      </div>
+    );
+  }
+
   // コンテンツの表示
   return (
     <div className="flex flex-col items-center justify-center p-4 space-y-4 pb-32">
+      {/* 検索フォーム */}
+      <div className="mb-8 flex flex-row items-center gap-2 overflow-x-auto">
+        {/* タグ検索 */}
+        <div className="flex items-center flex-shrink-0">
+          <input
+            type="text"
+            name="tags"
+            value={searchParams.tags}
+            onChange={handleInputChange}
+            placeholder="タグで検索（カンマ区切り）"
+            className="flex-grow min-w-[150px] p-2 border rounded-md"
+          />
+        </div>
+        {/* タイトル検索 */}
+        <div className="flex items-center flex-shrink-0">
+          <input
+            type="text"
+            name="title"
+            value={searchParams.title}
+            onChange={handleInputChange}
+            placeholder="タイトルで検索"
+            className="flex-grow min-w-[150px] p-2 border rounded-md"
+          />
+        </div>
+        {/* 作者名検索 */}
+        <div className="flex items-center flex-shrink-0">
+          <input
+            type="text"
+            name="author"
+            value={searchParams.author}
+            onChange={handleInputChange}
+            placeholder="作者名で検索"
+            className="flex-grow min-w-[150px] p-2 border rounded-md"
+          />
+        </div>
+        {/* 検索ボタン */}
+        <button
+          onClick={handleSearch}
+          className="p-2 bg-customButton text-white rounded-md hover:bg-opacity-80 flex-shrink-0"
+          disabled={isSearching}
+          aria-label="検索"
+          title="検索"
+        >
+          <FaSearch className="w-5 h-5" />
+        </button>
+        {/* クリアボタンを常にレンダリングし、表示・非表示を制御 */}
+        <button
+          onClick={handleResetSearch}
+          className={`p-2 bg-gray-400 text-white rounded-md hover:bg-gray-500 flex-shrink-0 ${
+            searchParams.tags || searchParams.title || searchParams.author ? "visible" : "invisible"
+          }`}
+          aria-label="クリア"
+          title="クリア"
+        >
+          <FaTimes className="w-5 h-5" />
+        </button>
+      </div>
+
       <BookList
-        books={publishedBooks}
+        books={isSearching ? filteredBooks : publishedBooks}
         pageType="bookListPage"
         rowStyles={rowStyles}
       />

--- a/front/src/app/index-books/BookListPage.jsx
+++ b/front/src/app/index-books/BookListPage.jsx
@@ -50,15 +50,18 @@ function BookListPage({ rowStyles = [] }) {
   };
 
   const handleSearch = () => {
+    const { tags, title, author } = storeSearchParams;
+    // 検索条件が空の場合は何もしない
+    if (!tags.trim() && !title.trim() && !author.trim()) {
+      return;
+    }
     searchBooks();
     // 必要に応じて URL を更新
     router.push(
       `/index-books?page=1${
-        storeSearchParams.tags ? `&tags=${encodeURIComponent(storeSearchParams.tags)}` : ""
-      }${
-        storeSearchParams.title ? `&title=${encodeURIComponent(storeSearchParams.title)}` : ""
-      }${
-        storeSearchParams.author ? `&author=${encodeURIComponent(storeSearchParams.author)}` : ""
+        tags ? `&tags=${encodeURIComponent(tags)}` : ""
+      }${title ? `&title=${encodeURIComponent(title)}` : ""}${
+        author ? `&author=${encodeURIComponent(author)}` : ""
       }`
     );
   };
@@ -132,8 +135,14 @@ function BookListPage({ rowStyles = [] }) {
         {/* 検索ボタン */}
         <button
           onClick={handleSearch}
-          className="p-2 bg-customButton text-white rounded-md hover:bg-opacity-80 flex-shrink-0"
-          disabled={isSearching}
+          className={`p-2 bg-customButton text-white rounded-md hover:bg-opacity-80 flex-shrink-0 ${
+            !storeSearchParams.tags.trim() &&
+            !storeSearchParams.title.trim() &&
+            !storeSearchParams.author.trim()
+              ? "opacity-50 cursor-not-allowed"
+              : ""
+          }`}
+          disabled={!storeSearchParams.tags.trim() && !storeSearchParams.title.trim() && !storeSearchParams.author.trim()}
           aria-label="検索"
           title="検索"
         >

--- a/front/src/app/index-books/page.jsx
+++ b/front/src/app/index-books/page.jsx
@@ -23,7 +23,7 @@ export default function Page() {
         <img
           src="/home/bookSherf1.png"
           alt="Book Shelf Bottom"
-          className={`absolute top-[-8px] left-1/2 transform -translate-x-1/2 w-[824px] h-[824px] object-contain pointer-events-none max-w-none max-h-none transition-opacity duration-300 ${loading ? 'opacity-50' : 'opacity-100'}`}
+          className={`absolute top-[-16px] left-1/2 transform -translate-x-1/2 w-[824px] h-[824px] object-contain pointer-events-none max-w-none max-h-none transition-opacity duration-300 ${loading ? 'opacity-50' : 'opacity-100'}`}
           style={{ zIndex: 7 }}
         />
         <img

--- a/front/src/app/index-books/page.jsx
+++ b/front/src/app/index-books/page.jsx
@@ -23,25 +23,25 @@ export default function Page() {
         <img
           src="/home/bookSherf1.png"
           alt="Book Shelf Bottom"
-          className={`absolute top-[-20px] left-1/2 transform -translate-x-1/2 w-[824px] h-[824px] object-contain pointer-events-none max-w-none max-h-none transition-opacity duration-300 ${loading ? 'opacity-50' : 'opacity-100'}`}
+          className={`absolute top-[-8px] left-1/2 transform -translate-x-1/2 w-[824px] h-[824px] object-contain pointer-events-none max-w-none max-h-none transition-opacity duration-300 ${loading ? 'opacity-50' : 'opacity-100'}`}
           style={{ zIndex: 7 }}
         />
         <img
           src="/home/bookSherf2.png"
           alt="Book Shelf Middle"
-          className={`absolute top-[-20px] left-1/2 transform -translate-x-1/2 w-[824px] h-[824px] object-contain pointer-events-none max-w-none max-h-none transition-opacity duration-300 ${loading ? 'opacity-50' : 'opacity-100'}`}
+          className={`absolute top-[-8px] left-1/2 transform -translate-x-1/2 w-[824px] h-[824px] object-contain pointer-events-none max-w-none max-h-none transition-opacity duration-300 ${loading ? 'opacity-50' : 'opacity-100'}`}
           style={{ zIndex: 5 }}
         />
         <img
           src="/home/bookSherf3.png"
           alt="Book Shelf Top"
-          className={`absolute top-[-20px] left-1/2 transform -translate-x-1/2 w-[824px] h-[824px] object-contain pointer-events-none max-w-none max-h-none transition-opacity duration-300 ${loading ? 'opacity-50' : 'opacity-100'}`}
+          className={`absolute top-[-8px] left-1/2 transform -translate-x-1/2 w-[824px] h-[824px] object-contain pointer-events-none max-w-none max-h-none transition-opacity duration-300 ${loading ? 'opacity-50' : 'opacity-100'}`}
           style={{ zIndex: 3 }}
         />
         <img
           src="/home/bookSherf4.png"
           alt="Book Shelf Highest"
-          className={`absolute top-[-20px] left-1/2 transform -translate-x-1/2 w-[824px] h-[824px] object-contain pointer-events-none max-w-none max-h-none transition-opacity duration-300 ${loading ? 'opacity-50' : 'opacity-100'}`}
+          className={`absolute top-[-8px] left-1/2 transform -translate-x-1/2 w-[824px] h-[824px] object-contain pointer-events-none max-w-none max-h-none transition-opacity duration-300 ${loading ? 'opacity-50' : 'opacity-100'}`}
           style={{ zIndex: 1 }}
         />
 

--- a/front/src/app/myPage/MyPage.jsx
+++ b/front/src/app/myPage/MyPage.jsx
@@ -108,6 +108,7 @@ function MyPage({ rowStyles = [] }) {
         handleEdit={handleEdit} // 編集ハンドラを渡す
         handleDelete={handleDelete} // 削除ハンドラを渡す
         rowStyles={rowStyles}
+        hoverTranslateYClass="hover:translate-y-[-8px]"
       />
       {/* Paginationコンポーネント */}
       <div className="mt-4">

--- a/front/src/app/myPage/MyPage.jsx
+++ b/front/src/app/myPage/MyPage.jsx
@@ -37,22 +37,6 @@ function MyPage({ rowStyles = [] }) {
   }, [setUserName]);
 
   useEffect(() => {
-    const fetchBooks = async () => {
-      try {
-        const params = {
-          page: currentPage,
-          per_page: perPage,
-        };
-        if (tagsQuery) {
-          params.tags = tagsQuery;
-        }
-        const response = await axiosInstance.get("/api/v1/books", { params });
-        setBooks(response.data);
-      } catch (error) {
-        console.error("書籍の取得に失敗しました:", error);
-      }
-    };
-    fetchBooks();
   }, [tagsQuery, currentPage, perPage]);
 
   // currentPage または isLoggedIn が変更されたときにデータをフェッチ

--- a/front/src/app/myPage/page.jsx
+++ b/front/src/app/myPage/page.jsx
@@ -32,30 +32,6 @@ export default function Page() {
         <h1 className="text-center text-3xl font-bold mb-2">{userName}さんの絵本</h1>
       </header>
       <div className="relative flex justify-center">
-        <img
-          src="/home/bookSherf1.png"
-          alt="Book Shelf Bottom"
-          className="absolute top-[-20px] left-1/2 transform -translate-x-1/2 w-[824px] h-[824px] object-contain pointer-events-none max-w-none max-h-none"
-          style={{ zIndex: 7 }}
-        />
-        <img
-          src="/home/bookSherf2.png"
-          alt="Book Shelf Middle"
-          className="absolute top-[-20px] left-1/2 transform -translate-x-1/2 w-[824px] h-[824px] object-contain pointer-events-none max-w-none max-h-none"
-          style={{ zIndex: 5 }}
-        />
-        <img
-          src="/home/bookSherf3.png"
-          alt="Book Shelf Top"
-          className="absolute top-[-20px] left-1/2 transform -translate-x-1/2 w-[824px] h-[824px] object-contain pointer-events-none max-w-none max-h-none"
-          style={{ zIndex: 3 }}
-        />
-        <img
-          src="/home/bookSherf4.png"
-          alt="Book Shelf Highest"
-          className="absolute top-[-20px] left-1/2 transform -translate-x-1/2 w-[824px] h-[824px] object-contain pointer-events-none max-w-none max-h-none"
-          style={{ zIndex: 1 }}
-        />
 
         {/* BookListPageを特定のレイヤーに挟む */}
         <div className="relative">

--- a/front/src/stores/booksStore.jsx
+++ b/front/src/stores/booksStore.jsx
@@ -2,9 +2,9 @@ import { create } from 'zustand';
 import axiosInstance from '../api/axios';
 
 const useBooksStore = create((set, get) => ({
-  publishedBooks: [], // 公開済みの絵本
+  publishedBooks: [],
   myBooks: [],
-  filteredBooks: [], // フィルタリングされた書籍
+  filteredBooks: [],
   pagination: {
     current_page: 1,
     next_page: null,

--- a/front/src/stores/booksStore.jsx
+++ b/front/src/stores/booksStore.jsx
@@ -1,9 +1,10 @@
 import { create } from 'zustand';
 import axiosInstance from '../api/axios';
 
-const useBooksStore = create((set) => ({
+const useBooksStore = create((set, get) => ({
   publishedBooks: [], // 公開済みの絵本
   myBooks: [],
+  filteredBooks: [], // フィルタリングされた書籍
   pagination: {
     current_page: 1,
     next_page: null,
@@ -12,9 +13,25 @@ const useBooksStore = create((set) => ({
     total_count: 0,
     limit_value: 9,
   },
+  searchParams: {
+    tags: "",
+    title: "",
+    author: "",
+  },
+  isSearching: false,
   loading: false,
   error: null,
+
   setPublishedBooks: (books) => set({ publishedBooks: books }),
+
+  // 検索パラメータの設定
+  setSearchParams: (params) => set({ searchParams: { ...get().searchParams, ...params } }),
+
+  // フィルタリングされた書籍を設定
+  setFilteredBooks: (books) => set({ filteredBooks: books }),
+
+  // 検索状態の設定
+  setIsSearching: (isSearching) => set({ isSearching }),
 
   // 公開済みの絵本をフェッチ
   fetchPublishedBooks: async (page = 1, perPage = 10, tags = null) => {
@@ -64,6 +81,68 @@ const useBooksStore = create((set) => ({
       console.error("Error fetching my books:", err);
       set({ error: err.message || "Error fetching my books", loading: false });
     }
+  },
+
+  // 検索機能
+searchBooks: async () => {
+  const { tags, title, author } = get().searchParams;
+  set({ isSearching: true, loading: true, error: null });
+  try {
+    const params = {
+      page: 1,
+      per_page: get().pagination.limit_value,
+    };
+    if (tags) params.tags = tags;
+    if (title.trim()) params.title = title.trim();
+    if (author.trim()) params.author = author.trim();
+
+    const response = await axiosInstance.get('/api/v1/books', { params });
+    const books = response.data.books;
+    const pagination = response.data.pagination || response.data.meta;
+
+    // 数値型に変換
+    const currentPage = Number(pagination.current_page);
+    const limitValue = Number(pagination.limit_value);
+
+    if (books && Array.isArray(books) && pagination && !isNaN(currentPage) && !isNaN(limitValue)) {
+      const sortedBooks = books.sort(
+        (a, b) => new Date(b.created_at) - new Date(a.created_at)
+      );
+      set({
+        filteredBooks: sortedBooks,
+        pagination: {
+          ...pagination,
+          current_page: currentPage,
+          limit_value: limitValue,
+        },
+        loading: false,
+        isSearching: true,
+      });
+    } else {
+      throw new Error("Invalid data format for searchBooks");
+    }
+  } catch (err) {
+    console.error("Error searching books:", err);
+    set({ error: err.message || "Error searching books", loading: false, isSearching: false });
+  }
+},
+
+  // 検索のリセット
+  resetSearch: () => {
+    set({
+      searchParams: { tags: "", title: "", author: "" },
+      filteredBooks: get().publishedBooks,
+      pagination: {
+        ...get().pagination,
+        current_page: 1,
+        next_page: null,
+        prev_page: null,
+        total_pages: 1,
+        total_count: get().publishedBooks.length,
+      },
+      error: null,
+      isSearching: false,
+    });
   },
 }));
 


### PR DESCRIPTION
## 概要
<!-- このセクションでは、このPRの目的と概要を簡潔に説明。 -->
- マイページから検索機能を削除し、`BookListPage` の検索機能に絞りました。
- ハッシュタグで検索した後、検索バーのプレースホルダーに選択したタグが入力されるように改善しました。
- 検索機能を `zustand` ストアで一元管理し、状態の扱いを効率化しました。
- 未入力状態では検索が実行されないように制御しました。

## やったこと
<!-- このプルリクで何をしたのか？ -->
- **マイページでの検索機能を削除**
  - タグやタイトル、作者名での検索機能を廃止。
  - 検索機能は `BookListPage` に限定。
- **ハッシュタグ検索後のプレースホルダー更新**
  - `#タグ` をクリックして検索した後、タグの名前が検索バーのプレースホルダーに表示されるように修正。
  - URLクエリパラメータの `tagsParam` を活用して反映。
- **検索機能の `zustand` での一元管理**
  - タグやタイトル、作者名での検索パラメータや状態を `zustand` ストアで管理。
  - 検索結果や状態のリセット、フィルタリング結果の保持を効率化。
- **未入力時の検索実行を無効化**
  - 入力が空の場合、検索が実行されないように制御。
  - 検索ボタンを押しても無効にし、ユーザーの操作ミスを防止。

## やらないこと
<!-- このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。） -->
- マイページでの検索機能再実装。

## できるようになること（ユーザ目線）
<!-- 何ができるようになるのか？（あれば。無いなら「無し」でOK） -->
- ハッシュタグをクリックすると、そのタグが検索バーのプレースホルダーに表示され、検索内容を直感的に確認できる。
- `BookListPage` に検索機能が統一され、操作が簡潔化される。
- 入力のない状態で検索が実行されることがなくなる。

## 動作確認
<!-- どのような動作確認を行ったのか？　結果はどうか？ -->
- ハッシュタグクリック後に、検索バーにプレースホルダーとしてタグが表示されることを確認。
- 未入力状態で検索が実行されないことを確認。
- `BookListPage` での検索機能が正常に動作することを確認。
- マイページで検索バーが表示されないことを確認。